### PR TITLE
Fix pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,13 @@
 repos:
-    -   repo: https://github.com/psf/black
-        rev: 19.3b0
-        hooks:
-        -   id: black
-    -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.4.0
-        hooks:
-        -   id: flake8
-    -   repo: https://github.com/pre-commit/mirrors-isort
-        rev: v4.3.21
-        hooks:
-        -    id: isort
-
-    default_language_version:
-        python: python3.7
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort


### PR DESCRIPTION
Due to some Yaml format errors in pre-commit config file, the hook
fails when try to run git commit. 

Also, requirement for Python v3.7 has been removed since Python code in
the repository is compatible with more recent versions.

<img width="519" alt="Screenshot 2022-02-03 at 22 40 39" src="https://user-images.githubusercontent.com/28781252/152443624-c1fbc6cb-dd13-4439-8a4d-b17340b7150b.png">
