### PR TITLE
Replace remappings by contract relative paths

### DIFF
--- a/contracts/contracts/Adjudicator.sol
+++ b/contracts/contracts/Adjudicator.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import "contracts/lib/ReEncryptionValidator.sol";
-import "contracts/lib/SignatureVerifier.sol";
-import "contracts/IStakingEscrow.sol";
-import "contracts/proxy/Upgradeable.sol";
-import "zeppelin/math/SafeMath.sol";
-import "zeppelin/math/Math.sol";
+import "./lib/ReEncryptionValidator.sol";
+import "./lib/SignatureVerifier.sol";
+import "./IStakingEscrow.sol";
+import "./proxy/Upgradeable.sol";
+import "../zeppelin/math/SafeMath.sol";
+import "../zeppelin/math/Math.sol";
 
 
 /**

--- a/contracts/contracts/IStakingEscrow.sol
+++ b/contracts/contracts/IStakingEscrow.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "contracts/NuCypherToken.sol";
+import "./NuCypherToken.sol";
 
 interface IStakingEscrow {
     function token() external view returns (NuCypherToken);

--- a/contracts/contracts/NuCypherToken.sol
+++ b/contracts/contracts/NuCypherToken.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 
-import "zeppelin/token/ERC20/ERC20.sol";
-import "zeppelin/token/ERC20/ERC20Detailed.sol";
+import "../zeppelin/token/ERC20/ERC20.sol";
+import "../zeppelin/token/ERC20/ERC20Detailed.sol";
 
 
 /**

--- a/contracts/contracts/PolicyManager.sol
+++ b/contracts/contracts/PolicyManager.sol
@@ -3,15 +3,15 @@
 pragma solidity ^0.8.0;
 
 
-import "zeppelin/token/ERC20/SafeERC20.sol";
-import "zeppelin/math/SafeMath.sol";
-import "zeppelin/math/Math.sol";
-import "zeppelin/utils/Address.sol";
-import "contracts/lib/AdditionalMath.sol";
-import "contracts/lib/SignatureVerifier.sol";
-import "contracts/NuCypherToken.sol";
-import "contracts/proxy/Upgradeable.sol";
-import "contracts/IStakingEscrow.sol";
+import "../zeppelin/token/ERC20/SafeERC20.sol";
+import "../zeppelin/math/SafeMath.sol";
+import "../zeppelin/math/Math.sol";
+import "../zeppelin/utils/Address.sol";
+import "./lib/AdditionalMath.sol";
+import "./lib/SignatureVerifier.sol";
+import "./NuCypherToken.sol";
+import "./proxy/Upgradeable.sol";
+import "./IStakingEscrow.sol";
 
 
 /**

--- a/contracts/contracts/SimplePREApplication.sol
+++ b/contracts/contracts/SimplePREApplication.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import "threshold/IStaking.sol";
+import "../threshold/IStaking.sol";
 
 
 /**

--- a/contracts/contracts/StakingEscrow.sol
+++ b/contracts/contracts/StakingEscrow.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 
-import "aragon/interfaces/IERC900History.sol";
-import "contracts/NuCypherToken.sol";
-import "contracts/lib/Bits.sol";
-import "contracts/proxy/Upgradeable.sol";
-import "zeppelin/math/Math.sol";
-import "zeppelin/token/ERC20/SafeERC20.sol";
-import "threshold/IStaking.sol";
+import "../aragon/interfaces/IERC900History.sol";
+import "./NuCypherToken.sol";
+import "./lib/Bits.sol";
+import "./proxy/Upgradeable.sol";
+import "../zeppelin/math/Math.sol";
+import "../zeppelin/token/ERC20/SafeERC20.sol";
+import "../threshold/IStaking.sol";
 
 
 /**

--- a/contracts/contracts/WorkLock.sol
+++ b/contracts/contracts/WorkLock.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0; // TODO use 0.7.x version and revert changes ?
 
 
-import "zeppelin/math/SafeMath.sol";
-import "zeppelin/token/ERC20/SafeERC20.sol";
-import "zeppelin/utils/Address.sol";
-import "zeppelin/ownership/Ownable.sol";
-import "contracts/NuCypherToken.sol";
-import "contracts/IStakingEscrow.sol";
-import "contracts/lib/AdditionalMath.sol";
+import "../zeppelin/math/SafeMath.sol";
+import "../zeppelin/token/ERC20/SafeERC20.sol";
+import "../zeppelin/utils/Address.sol";
+import "../zeppelin/ownership/Ownable.sol";
+import "./NuCypherToken.sol";
+import "./IStakingEscrow.sol";
+import "./lib/AdditionalMath.sol";
 
 
 /**

--- a/contracts/contracts/dao/Voting.sol
+++ b/contracts/contracts/dao/Voting.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "contracts/dao/IForwarder.sol";
+import "./IForwarder.sol";
 
 // Interface for Voting contract, as found in https://github.com/aragon/aragon-apps/blob/master/apps/voting/contracts/Voting.sol
 interface Voting is IForwarder{

--- a/contracts/contracts/lib/AdditionalMath.sol
+++ b/contracts/contracts/lib/AdditionalMath.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import "zeppelin/math/SafeMath.sol";
+import "../../zeppelin/math/SafeMath.sol";
 
 
 /**

--- a/contracts/contracts/lib/ReEncryptionValidator.sol
+++ b/contracts/contracts/lib/ReEncryptionValidator.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "contracts/lib/UmbralDeserializer.sol";
-import "contracts/lib/SignatureVerifier.sol";
+import "./UmbralDeserializer.sol";
+import "./SignatureVerifier.sol";
 
 /**
 * @notice Validates re-encryption correctness.

--- a/contracts/contracts/proxy/Dispatcher.sol
+++ b/contracts/contracts/proxy/Dispatcher.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 
 import "./Upgradeable.sol";
-import "zeppelin/utils/Address.sol";
+import "../../zeppelin/utils/Address.sol";
 
 
 /**

--- a/contracts/contracts/proxy/Upgradeable.sol
+++ b/contracts/contracts/proxy/Upgradeable.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import "zeppelin/ownership/Ownable.sol";
+import "../../zeppelin/ownership/Ownable.sol";
 
 
 /**

--- a/contracts/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/contracts/contracts/staking_contracts/AbstractStakingContract.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import "zeppelin/ownership/Ownable.sol";
-import "zeppelin/utils/Address.sol";
-import "zeppelin/token/ERC20/SafeERC20.sol";
-import "contracts/staking_contracts/StakingInterface.sol";
-import "zeppelin/proxy/Initializable.sol";
+import "../../zeppelin/ownership/Ownable.sol";
+import "../../zeppelin/utils/Address.sol";
+import "../../zeppelin/token/ERC20/SafeERC20.sol";
+import "./StakingInterface.sol";
+import "../../zeppelin/proxy/Initializable.sol";
 
 
 /**

--- a/contracts/contracts/staking_contracts/PoolingStakingContractV2.sol
+++ b/contracts/contracts/staking_contracts/PoolingStakingContractV2.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "zeppelin/ownership/Ownable.sol";
-import "contracts/staking_contracts/AbstractStakingContract.sol";
+import "../../zeppelin/ownership/Ownable.sol";
+import "./AbstractStakingContract.sol";
 
 /**
  * @notice Contract acts as delegate for sub-stakers

--- a/contracts/contracts/staking_contracts/StakingInterface.sol
+++ b/contracts/contracts/staking_contracts/StakingInterface.sol
@@ -3,12 +3,12 @@
 pragma solidity ^0.8.0;
 
 
-import "contracts/staking_contracts/AbstractStakingContract.sol";
-import "contracts/NuCypherToken.sol";
-import "contracts/IStakingEscrow.sol";
-import "contracts/PolicyManager.sol";
-import "contracts/WorkLock.sol";
-import "threshold/IStaking.sol";
+import "./AbstractStakingContract.sol";
+import "../NuCypherToken.sol";
+import "../IStakingEscrow.sol";
+import "../PolicyManager.sol";
+import "../WorkLock.sol";
+import "../../threshold/IStaking.sol";
 
 
 /**

--- a/contracts/zeppelin/token/ERC20/ERC20.sol
+++ b/contracts/zeppelin/token/ERC20/ERC20.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import "zeppelin/token/ERC20/IERC20.sol";
+import "./IERC20.sol";
 
 
 /**

--- a/contracts/zeppelin/token/ERC20/SafeERC20.sol
+++ b/contracts/zeppelin/token/ERC20/SafeERC20.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.0;
 
-import "zeppelin/token/ERC20/IERC20.sol";
-import "zeppelin/utils/Address.sol";
+import "./IERC20.sol";
+import "../../utils/Address.sol";
 
 /**
  * @title SafeERC20


### PR DESCRIPTION
In order to have a framework-agnostic repository for NuCypher contracts,
it's recommended to avoid the use of remappings, since the set-up of
these may be different for each IDE/framework.

Also, the non-use of remappings facilitates the use of
nucypher-contracts as NPM package.