### PR TITLE
Add support for NPM packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nucypher-contracts",
+  "version": "0.0.1",
+  "license": "AGPL-3.0-or-later",
+  "description": "NuCypher Network Smart Contracts",
+  "author": "NuCypher"
+}


### PR DESCRIPTION
Adding an NPM package.json file allows the NuCypher contracts to be
treated as an NPM package, which facilitates the import of the contracts
in Node.js frameworks such as Hardhat.