### PR TITLE
Add @nucypher scope to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nucypher-contracts",
-  "version": "0.0.1",
+  "name": "@nucypher/nucypher-contracts",
+  "version": "0.1.0",
   "license": "AGPL-3.0-or-later",
   "description": "NuCypher Network Smart Contracts",
   "author": "NuCypher"


### PR DESCRIPTION
Since this NPM package belongs to NuCypher organization, it's needed to
preceed the name with the organization name (a.k.a. NPM scope).