### PR TITLE
Add "artifacts" folder to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "/contracts/**/*.sol",
     "/build/contracts/*.json",
+    "/artifacts/*.json",
     "!/contracts/test/**/*"
   ]
 }


### PR DESCRIPTION
Artifacts folder includes the ABIs and addresses of deployed contracts.
So it's necessary to include it in the NPM package when it's generated
by npm publish command.