### PR TITLE
Update black version in pre-commit to avoid issues with click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,14 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
     -   id: black
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
     -   id: flake8
+
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:


### PR DESCRIPTION
I've run into issues when committing. Black and pre-commit have stopped playing nicely, but it was fixed in a more recent version of black.

https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click