### PR TITLE
Change `requestEncryptingKey` to `decryptionRequestStaticKey` now that we are using DH via curve 25519

### DIFF
--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -39,7 +39,7 @@ contract Coordinator is Ownable {
         address provider;
         bool aggregated;
         bytes transcript;  // TODO: Consider event processing complexity vs storage cost
-        bytes requestEncryptingKey;
+        bytes decryptionRequestStaticKey;
     }
 
     // TODO: Optimize layout
@@ -187,7 +187,7 @@ contract Coordinator is Ownable {
         uint32 ritualId,
         bytes calldata aggregatedTranscript,
         BLS12381.G1Point calldata publicKey,
-        bytes calldata requestEncryptingKey
+        bytes calldata decryptionRequestStaticKey
     ) external {
         Ritual storage ritual = rituals[ritualId];
         require(
@@ -208,14 +208,14 @@ contract Coordinator is Ownable {
         );
 
         require(
-            participant.requestEncryptingKey.length == 0,
+            participant.decryptionRequestStaticKey.length == 0,
             "Node already provided request encrypting key"
         );
 
         // nodes commit to their aggregation result
         bytes32 aggregatedTranscriptDigest = keccak256(aggregatedTranscript);
         participant.aggregated = true;
-        participant.requestEncryptingKey = requestEncryptingKey;  // TODO validation?
+        participant.decryptionRequestStaticKey = decryptionRequestStaticKey;  // TODO validation?
         emit AggregationPosted(ritualId, provider, aggregatedTranscriptDigest);
 
         if (ritual.aggregatedTranscript.length == 0) {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -91,7 +91,7 @@ def test_post_transcript(coordinator, nodes, initiator):
     participants = coordinator.getParticipants(0)
     for participant in participants:
         assert not participant.aggregated
-        assert not participant.requestEncryptingKey
+        assert not participant.decryptionRequestStaticKey
 
     assert coordinator.getRitualState(0) == RitualState.AWAITING_AGGREGATIONS
 
@@ -126,12 +126,12 @@ def test_post_aggregation(coordinator, nodes, initiator):
         coordinator.postTranscript(0, transcript, sender=node)
 
     aggregated = os.urandom(10)
-    requestEncryptingKeys = [os.urandom(32) for node in nodes]
+    decryptionRequestStaticKeys = [os.urandom(58) for node in nodes]
     publicKey = (os.urandom(32), os.urandom(16))
     for i, node in enumerate(nodes):
         assert coordinator.getRitualState(0) == RitualState.AWAITING_AGGREGATIONS
         tx = coordinator.postAggregation(
-            0, aggregated, publicKey, requestEncryptingKeys[i], sender=node
+            0, aggregated, publicKey, decryptionRequestStaticKeys[i], sender=node
         )
 
         events = list(coordinator.AggregationPosted.from_receipt(tx))
@@ -144,7 +144,7 @@ def test_post_aggregation(coordinator, nodes, initiator):
     participants = coordinator.getParticipants(0)
     for i, participant in enumerate(participants):
         assert participant.aggregated
-        assert participant.requestEncryptingKey == requestEncryptingKeys[i]
+        assert participant.decryptionRequestStaticKey == decryptionRequestStaticKeys[i]
 
     assert coordinator.getRitualState(0) == RitualState.FINALIZED
     events = list(coordinator.EndRitual.from_receipt(tx))


### PR DESCRIPTION
Now that we are using a DH shared secret for encryption/decryption of ThresholdDecryptionRequest/Response, using the term `requestEncryptingKey` for the Participant's public key for decryption requests is not exactly correct. 

This key is the public key to use for deriving the DH shared secret. The term is now `decryptionRequestStaticKey`; alternative names are welcomed (cc @cygnusv).

Related to:
- https://github.com/nucypher/nucypher/issues/3129
- https://github.com/nucypher/nucypher/issues/3134