### PR TITLE
Beefing up the Coordinator: Restrictions to initiator, ritual duration, fee model, automatic TX reimbursements, etc

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -11,10 +11,10 @@ plugins:
 dependencies:
   - name: openzeppelin
     github: OpenZeppelin/openzeppelin-contracts
-    version: 4.8.1
+    version: 4.9.1
   - name: openzeppelin-upgradeable
     github: OpenZeppelin/openzeppelin-contracts-upgradeable
-    version: 4.8.1
+    version: 4.9.1
   - name: fx-portal
     github: 0xPolygon/fx-portal
     version: 1.0.5
@@ -23,8 +23,8 @@ solidity:
   version: 0.8.20
   evm_version: paris
   import_remapping:
-    - "@openzeppelin/contracts=openzeppelin/v4.8.1"
-    - "@openzeppelin-upgradeable/contracts=openzeppelin-upgradeable/v4.8.1"
+    - "@openzeppelin/contracts=openzeppelin/v4.9.1"
+    - "@openzeppelin-upgradeable/contracts=openzeppelin-upgradeable/v4.9.1"
     - "@fx-portal/contracts=fx-portal/v1.0.5"
 
 deployments:

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -29,7 +29,14 @@ solidity:
 
 deployments:
   polygon:
+    mainnet:
+      - contract_type: DAI
+        address: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063'
     mumbai:
+      - contract_type: DAI
+        address: '0x001B3B4d0F3714Ca98ba10F6042DaEbF0B1B7b6F'
+      - contract_type: StakeInfo
+        address: '0xC1379866Fb0c100DCBFAb7b470009C4827D47DD8'
       - fx_child: '0xCf73231F28B7331BBe3124B907840A94851f9f11'
       - verify: False
   ethereum:

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -262,13 +262,18 @@ contract Coordinator is AccessControlDefaultAdminRules {
 
         require(
             participant.decryptionRequestStaticKey.length == 0,
-            "Node already provided request encrypting key"
+            "Node already provided decryption request static key"
+        );
+
+        require(
+            decryptionRequestStaticKey.length == 42,
+            "Invalid length for decryption request static key"
         );
 
         // nodes commit to their aggregation result
         bytes32 aggregatedTranscriptDigest = keccak256(aggregatedTranscript);
         participant.aggregated = true;
-        participant.decryptionRequestStaticKey = decryptionRequestStaticKey;  // TODO validation?
+        participant.decryptionRequestStaticKey = decryptionRequestStaticKey;
         emit AggregationPosted(ritualId, provider, aggregatedTranscriptDigest);
 
         if (ritual.aggregatedTranscript.length == 0) {

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -114,11 +114,6 @@ contract Coordinator is AccessControlDefaultAdminRules {
     }
 
     function makeInitiationPublic() external onlyRole(DEFAULT_ADMIN_ROLE) {
-        // Revoke all addresses with INITIATOR_ROLE
-        uint256 length = getRoleMemberCount(INITIATOR_ROLE);
-        for(uint i = 0; i < length; i++){
-            _revokeRole(INITIATOR_ROLE, getRoleMember(INITIATOR_ROLE, i));
-        }
         isInitiationPublic = true;
         _setRoleAdmin(INITIATOR_ROLE, bytes32(0));
     }
@@ -172,7 +167,7 @@ contract Coordinator is AccessControlDefaultAdminRules {
         Ritual storage ritual = rituals.push();
         ritual.initiator = msg.sender;
         ritual.authority = authority;
-        ritual.dkgSize = uint32(length);
+        ritual.dkgSize = uint16(length);
         ritual.initTimestamp = uint32(block.timestamp);
         ritual.endTimestamp = ritual.initTimestamp + duration;
 
@@ -333,7 +328,7 @@ contract Coordinator is AccessControlDefaultAdminRules {
     }
     
     function processReimbursement(uint256 initialGasLeft) internal {
-        if(reimbursementPool != address(0)){ // TODO: Consider defining a method
+        if(address(reimbursementPool) != address(0)){ // TODO: Consider defining a method
             uint256 gasUsed = initialGasLeft - gasleft();
             try reimbursementPool.refund(gasUsed, msg.sender) {
                 return;

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -16,7 +16,7 @@ contract Coordinator is AccessControl {
     event StartRitual(uint32 indexed ritualId, address indexed initiator, address[] participants);
     event StartAggregationRound(uint32 indexed ritualId);
     // TODO: Do we want the public key here? If so, we want 2 events or do we reuse this event?
-    event EndRitual(uint32 indexed ritualId, address indexed initiator, bool successful);
+    event EndRitual(uint32 indexed ritualId, bool successful);
 
     // Node
     event TranscriptPosted(uint32 indexed ritualId, address indexed node, bytes32 transcriptDigest);
@@ -257,7 +257,6 @@ contract Coordinator is AccessControl {
             ritual.aggregationMismatch = true;
             emit EndRitual({
                 ritualId: ritualId,
-                initiator: ritual.authority,
                 successful: false
             });
             // TODO: Consider freeing ritual storage
@@ -268,7 +267,6 @@ contract Coordinator is AccessControl {
         if (ritual.totalAggregations == ritual.dkgSize){
             emit EndRitual({
                 ritualId: ritualId,
-                initiator: ritual.authority,
                 successful: true
             });
             // TODO: Consider including public key in event

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -281,18 +281,17 @@ contract Coordinator is AccessControlDefaultAdminRules {
                 ritualId: ritualId,
                 successful: false
             });
-            // TODO: Consider freeing ritual storage
-            processReimbursement(initialGasLeft);
-            return;
         }
 
-        ritual.totalAggregations++;
-        if (ritual.totalAggregations == ritual.dkgSize){
-            emit EndRitual({
-                ritualId: ritualId,
-                successful: true
-            });
-            // TODO: Consider including public key in event
+        if(!ritual.aggregationMismatch){
+            ritual.totalAggregations++;
+            if (ritual.totalAggregations == ritual.dkgSize){
+                emit EndRitual({
+                    ritualId: ritualId,
+                    successful: true
+                });
+                // TODO: Consider including public key in event
+            }
         }
         processReimbursement(initialGasLeft);
     }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/access/AccessControlDefaultAdminRules.sol";
 import "../lib/BLS12381.sol";
 import "../../threshold/IAccessControlApplication.sol";
 
@@ -10,7 +10,7 @@ import "../../threshold/IAccessControlApplication.sol";
 * @title Coordinator
 * @notice Coordination layer for DKG-TDec
 */
-contract Coordinator is AccessControl {
+contract Coordinator is AccessControlDefaultAdminRules {
 
     // Ritual
     event StartRitual(uint32 indexed ritualId, address indexed initiator, address[] participants);
@@ -57,7 +57,6 @@ contract Coordinator is AccessControl {
         Participant[] participant;
     }
 
-    bytes32 public constant PARAMETER_ADMIN_ROLE = keccak256("PARAMETER_ADMIN_ROLE");
     bytes32 public constant INITIATOR_ROLE = keccak256("INITIATOR_ROLE");
 
     IAccessControlApplication public immutable application;
@@ -71,14 +70,14 @@ contract Coordinator is AccessControl {
         IAccessControlApplication app,
         uint32 _timeout,
         uint16 _maxDkgSize,
-        address parameterAdmin,
+        address _admin,
         address[] initiators // change to a setter function instead?
-    ) {
+    ) AccessControlDefaultAdminRules(0, _admin)
+    {
         application = app;
         timeout = _timeout;
         maxDkgSize = _maxDkgSize;
 
-        _grantRole(PARAMETER_ADMIN_ROLE, parameterAdmin);
         for(uint i = 0; i < initiators.length; i++){
             _grantRole(INITIATOR_ROLE, initiators[i]);
         }
@@ -114,12 +113,12 @@ contract Coordinator is AccessControl {
     }
 
 
-    function setTimeout(uint32 newTimeout) external onlyRole(PARAMETER_ADMIN_ROLE) {
+    function setTimeout(uint32 newTimeout) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit TimeoutChanged(timeout, newTimeout);
         timeout = newTimeout;
     }
 
-    function setMaxDkgSize(uint16 newSize) external onlyRole(PARAMETER_ADMIN_ROLE) {
+    function setMaxDkgSize(uint16 newSize) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit MaxDkgSizeChanged(maxDkgSize, newSize);
         maxDkgSize = newSize;
     }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -17,7 +17,7 @@ import "../../threshold/IAccessControlApplication.sol";
 contract Coordinator is AccessControlDefaultAdminRules {
 
     // Ritual
-    event StartRitual(uint32 indexed ritualId, address indexed initiator, address[] participants);
+    event StartRitual(uint32 indexed ritualId, address indexed authority, address[] participants);
     event StartAggregationRound(uint32 indexed ritualId);
     // TODO: Do we want the public key here? If so, we want 2 events or do we reuse this event?
     event EndRitual(uint32 indexed ritualId, bool successful);
@@ -135,13 +135,13 @@ contract Coordinator is AccessControlDefaultAdminRules {
     }
 
     function setReimbursementPool(IReimbursementPool pool) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (address(pool) == address(0)){
-            delete reimbursementPool;
-        } else {
-            require(pool.isAuthorized(address(this)), "Coordinator not authorized");
-            reimbursementPool = pool;
-            // TODO: Events
-        }
+        require(
+            address(pool) == address(0) || 
+            pool.isAuthorized(address(this)),
+            "Invalid ReimbursementPool"
+        );
+        reimbursementPool = pool;
+        // TODO: Events
     }
 
     function numberOfRituals() external view returns(uint256) {

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -72,14 +72,15 @@ contract Coordinator is AccessControlDefaultAdminRules {
     IReimbursementPool reimbursementPool;
 
     constructor(
-        IAccessControlApplication app,
+        IAccessControlApplication _stakes,
         uint32 _timeout,
         uint16 _maxDkgSize,
         address _admin,
         IFeeModel _feeModel
     ) AccessControlDefaultAdminRules(0, _admin)
     {
-        application = app;
+        require(address(_feeModel.stakes()) == address(_stakes), "Invalid stakes for fee model");
+        application = _stakes;
         timeout = _timeout;
         maxDkgSize = _maxDkgSize;
         feeModel = IFeeModel(_feeModel);

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControlDefaultAdminRules.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./IFeeModel.sol";
 import "./IReimbursementPool.sol";
 import "../lib/BLS12381.sol";
@@ -59,6 +60,8 @@ contract Coordinator is AccessControlDefaultAdminRules {
         bytes aggregatedTranscript;
         Participant[] participant;
     }
+
+    using SafeERC20 for IERC20;
 
     bytes32 public constant INITIATOR_ROLE = keccak256("INITIATOR_ROLE");
 
@@ -334,7 +337,7 @@ contract Coordinator is AccessControlDefaultAdminRules {
             assert(pendingFees[ritualID] == 0);  // TODO: This is an invariant, not sure if actually needed
             pendingFees[ritualID] += ritualCost;
             IERC20 currency = IERC20(feeModel.currency());
-            currency.transferFrom(msg.sender, address(this), ritualCost);
+            currency.safeTransferFrom(msg.sender, address(this), ritualCost);
             // TODO: Define methods to manage these funds
         }
     }

--- a/contracts/contracts/coordination/FlateRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlateRateFeeModel.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "./IFeeModel.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+* @title FlatRateFeeModel
+* @notice FlateRateFeeModel
+*/
+contract FlatRateFeeModel is IFeeModel {
+
+    IERC20 public immutable currency;
+    uint256 public immutable feeRatePerSecond;
+
+    constructor(IERC20 _currency, uint256 _feeRatePerSecond){
+        currency = _currency;
+        feeRatePerSecond = _feeRatePerSecond;
+    }
+
+    function getRitualInitiationCost(
+        address[] calldata providers,
+        uint32 duration
+    ) external view returns(uint256){
+        uint256 size = providers.length;
+        require(duration > 0, "Invalid ritual duration");
+        require(size > 0, "Invalid ritual size");
+        return feeRatePerSecond * size * duration;
+    }
+}

--- a/contracts/contracts/coordination/FlateRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlateRateFeeModel.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "./IFeeModel.sol";
+import "../../threshold/IAccessControlApplication.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
@@ -13,10 +14,12 @@ contract FlatRateFeeModel is IFeeModel {
 
     IERC20 public immutable currency;
     uint256 public immutable feeRatePerSecond;
+    IAccessControlApplication public immutable stakes;
 
-    constructor(IERC20 _currency, uint256 _feeRatePerSecond){
+    constructor(IERC20 _currency, uint256 _feeRatePerSecond, address _stakes){
         currency = _currency;
         feeRatePerSecond = _feeRatePerSecond;
+        stakes = IAccessControlApplication(_stakes);
     }
 
     function getRitualInitiationCost(

--- a/contracts/contracts/coordination/IFeeModel.sol
+++ b/contracts/contracts/coordination/IFeeModel.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../../threshold/IAccessControlApplication.sol";
 
 /**
 * @title IFeeModel
@@ -10,5 +11,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 */
 interface IFeeModel {
     function currency() external view returns(IERC20);
+    function stakes() external view returns(IAccessControlApplication);
     function getRitualInitiationCost(address[] calldata providers, uint32 duration) external view returns(uint256);
 }

--- a/contracts/contracts/coordination/IFeeModel.sol
+++ b/contracts/contracts/coordination/IFeeModel.sol
@@ -2,11 +2,13 @@
 
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 /**
 * @title IFeeModel
 * @notice IFeeModel
 */
 interface IFeeModel {
-    function currency() external pure returns(address);
+    function currency() external view returns(IERC20);
     function getRitualInitiationCost(address[] calldata providers, uint32 duration) external view returns(uint256);
 }

--- a/contracts/contracts/coordination/IFeeModel.sol
+++ b/contracts/contracts/coordination/IFeeModel.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+/**
+* @title IFeeModel
+* @notice IFeeModel
+*/
+interface IFeeModel {
+    function currency() external pure returns(address);
+    function getRitualInitiationCost(address[] calldata providers, uint32 duration) external view returns(uint256);
+}

--- a/contracts/contracts/coordination/IReimbursementPool.sol
+++ b/contracts/contracts/coordination/IReimbursementPool.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+/**
+* @title IReimbursementPool
+* @notice IReimbursementPool
+*/
+interface IReimbursementPool {
+    function isAuthorized(address caller) external view returns(bool);
+    function refund(uint256 gasSpent, address receiver) external;
+}

--- a/scripts/deploy_flat_rate_fee_model.py
+++ b/scripts/deploy_flat_rate_fee_model.py
@@ -21,8 +21,6 @@ def cli(network, account, currency, rate, verify):
     deployer = account #get_account(account_id)
     click.echo(f"Deployer: {deployer}")
 
-
-
     if rate and currency == ZERO_ADDRESS:
         raise ValueError("ERC20 contract address needed for currency")
     
@@ -51,11 +49,20 @@ def cli(network, account, currency, rate, verify):
     except KeyError:
         pass  # TODO: Further validate currency address?
     else:
-        currency = next(d for d in deployments if d["contract_type"] == currency)['address']
+        try:
+            currency = next(d for d in deployments if d["contract_type"] == currency)["address"]
+        except StopIteration:
+            pass
+        
+        try:
+            stakes = next(d for d in deployments if d["contract_type"] == "StakeInfo")["address"]
+        except StopIteration:
+            raise ValueError("StakeInfo deployment needed")
 
     flat_rate_fee_model = project.FlatRateFeeModel.deploy(
         currency,
         rate,
+        stakes,
         sender=deployer,
         publish=verify,
     )

--- a/scripts/deploy_flat_rate_fee_model.py
+++ b/scripts/deploy_flat_rate_fee_model.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+import os
+
+from ape import config, project, networks
+from ape.cli import account_option, network_option, NetworkBoundCommand
+from ape.utils import ZERO_ADDRESS
+
+from ape_etherscan.utils import API_KEY_ENV_KEY_MAP
+
+import click
+
+
+@click.command(cls=NetworkBoundCommand)
+@network_option()
+@account_option()
+@click.option('--currency', default=ZERO_ADDRESS)
+@click.option('--rate', default=0)
+@click.option('--verify/--no-verify', default=True)
+def cli(network, account, currency, rate, verify):
+    deployer = account #get_account(account_id)
+    click.echo(f"Deployer: {deployer}")
+
+
+
+    if rate and currency == ZERO_ADDRESS:
+        raise ValueError("ERC20 contract address needed for currency")
+    
+    # Network
+    ecosystem_name = networks.provider.network.ecosystem.name
+    network_name = networks.provider.network.name
+    provider_name = networks.provider.name
+    click.echo(f"You are connected to network '{ecosystem_name}:{network_name}:{provider_name}'.")
+
+    # TODO: Move this to a common deployment utilities module
+    # Validate Etherscan verification parameters.
+    # This import fails if called before the click network options are evaluated
+    from scripts.utils import LOCAL_BLOCKCHAIN_ENVIRONMENTS
+    is_public_deployment = network_name not in LOCAL_BLOCKCHAIN_ENVIRONMENTS
+    if not is_public_deployment:
+        verify = False
+    elif verify:
+        env_var_key = API_KEY_ENV_KEY_MAP.get(ecosystem_name)
+        api_key = os.environ.get(env_var_key)
+        if not api_key:
+            raise ValueError(f"{env_var_key} is not set")
+
+    # Use deployment information for currency, if possible
+    try:
+        deployments = config.deployments[ecosystem_name][network_name]
+    except KeyError:
+        pass  # TODO: Further validate currency address?
+    else:
+        currency = next(d for d in deployments if d["contract_type"] == currency)['address']
+
+    flat_rate_fee_model = project.FlatRateFeeModel.deploy(
+        currency,
+        rate,
+        sender=deployer,
+        publish=verify,
+    )
+    return flat_rate_fee_model

--- a/scripts/deploy_subscription_manager.py
+++ b/scripts/deploy_subscription_manager.py
@@ -8,7 +8,7 @@ INITIAL_FEE_RATE = Web3.to_wei(1, "gwei")
 
 def main(id=None):
     deployer = get_account(id)
-    dependency = project.dependencies["openzeppelin"]["4.8.1"]
+    dependency = project.dependencies["openzeppelin"]["4.9.1"]
 
     proxy_admin = deployer.deploy(dependency.ProxyAdmin)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,6 +5,7 @@ import ape
 import pytest
 from web3 import Web3
 
+TRANSCRIPT_SIZE = 500
 TIMEOUT = 1000
 MAX_DKG_SIZE = 64
 
@@ -78,7 +79,7 @@ def test_post_transcript(coordinator, nodes, initiator):
     for node in nodes:
         assert coordinator.getRitualState(0) == RitualState.AWAITING_TRANSCRIPTS
 
-        transcript = os.urandom(10)
+        transcript = os.urandom(TRANSCRIPT_SIZE)
         tx = coordinator.postTranscript(0, transcript, sender=node)
 
         events = list(coordinator.TranscriptPosted.from_receipt(tx))
@@ -99,33 +100,33 @@ def test_post_transcript(coordinator, nodes, initiator):
 def test_post_transcript_but_not_part_of_ritual(coordinator, nodes, initiator):
     coordinator.initiateRitual(nodes, sender=initiator)
     with ape.reverts("Participant not part of ritual"):
-        coordinator.postTranscript(0, os.urandom(10), sender=initiator)
+        coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=initiator)
 
 
 def test_post_transcript_but_already_posted_transcript(coordinator, nodes, initiator):
     coordinator.initiateRitual(nodes, sender=initiator)
-    coordinator.postTranscript(0, os.urandom(10), sender=nodes[0])
+    coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[0])
     with ape.reverts("Node already posted transcript"):
-        coordinator.postTranscript(0, os.urandom(10), sender=nodes[0])
+        coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[0])
 
 
 def test_post_transcript_but_not_waiting_for_transcripts(coordinator, nodes, initiator):
     coordinator.initiateRitual(nodes, sender=initiator)
     for node in nodes:
-        transcript = os.urandom(10)
+        transcript = os.urandom(TRANSCRIPT_SIZE)
         coordinator.postTranscript(0, transcript, sender=node)
 
     with ape.reverts("Not waiting for transcripts"):
-        coordinator.postTranscript(0, os.urandom(10), sender=nodes[1])
+        coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[1])
 
 
 def test_post_aggregation(coordinator, nodes, initiator):
     coordinator.initiateRitual(nodes, sender=initiator)
-    transcript = os.urandom(10)
+    transcript = os.urandom(TRANSCRIPT_SIZE)
     for node in nodes:
         coordinator.postTranscript(0, transcript, sender=node)
 
-    aggregated = os.urandom(10)
+    aggregated = os.urandom(TRANSCRIPT_SIZE)
     decryptionRequestStaticKeys = [os.urandom(58) for node in nodes]
     publicKey = (os.urandom(32), os.urandom(16))
     for i, node in enumerate(nodes):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,9 @@ from web3 import Web3
 TRANSCRIPT_SIZE = 500
 TIMEOUT = 1000
 MAX_DKG_SIZE = 64
+FEE_RATE = 42
+ERC20_SUPPLY = 10**24
+DURATION = 1234
 
 RitualState = IntEnum(
     "RitualState",
@@ -34,8 +37,12 @@ def initiator(accounts):
 
 
 @pytest.fixture(scope="module")
-def stake_info(project, accounts, nodes):
-    deployer = accounts[8]
+def deployer(accounts):
+    return accounts[8]
+
+
+@pytest.fixture()
+def stake_info(project, deployer, nodes):
     contract = project.StakeInfo.deploy([deployer], sender=deployer)
     for n in nodes:
         contract.updateOperator(n, n, sender=deployer)
@@ -43,9 +50,37 @@ def stake_info(project, accounts, nodes):
     return contract
 
 
-@pytest.fixture(scope="module")
-def coordinator(project, accounts, stake_info):
-    return project.Coordinator.deploy(stake_info.address, TIMEOUT, MAX_DKG_SIZE, sender=accounts[8])
+@pytest.fixture()
+def erc20(project, initiator):
+    # Create an ERC20 token (using NuCypherToken because it's easier, but could be any ERC20)
+    token = project.NuCypherToken.deploy(ERC20_SUPPLY, sender=initiator)
+    return token
+
+
+@pytest.fixture()
+def flat_rate_fee_model(project, deployer, stake_info, erc20):
+    contract = project.FlatRateFeeModel.deploy(
+        erc20.address,
+        FEE_RATE,
+        stake_info.address,
+        sender=deployer
+    )
+    return contract
+
+
+@pytest.fixture()
+def coordinator(project, deployer, stake_info, flat_rate_fee_model, initiator):
+    admin = deployer
+    contract = project.Coordinator.deploy(
+        stake_info.address,
+        TIMEOUT,
+        MAX_DKG_SIZE,
+        admin,
+        flat_rate_fee_model.address,
+        sender=deployer
+    )
+    contract.grantRole(contract.INITIATOR_ROLE(), initiator, sender=admin)
+    return contract
 
 
 def test_initial_parameters(coordinator):
@@ -54,14 +89,29 @@ def test_initial_parameters(coordinator):
     assert coordinator.numberOfRituals() == 0
 
 
-def test_initiate_ritual(coordinator, nodes, initiator):
+def test_invalid_initiate_ritual(coordinator, nodes, accounts, initiator):
+    with ape.reverts("Sender can't initiate ritual"):
+        sender = accounts[3]
+        coordinator.initiateRitual(nodes, sender, DURATION, sender=sender)
+
     with ape.reverts("Invalid number of nodes"):
-        coordinator.initiateRitual(nodes[:5] * 20, sender=initiator)
+        coordinator.initiateRitual(nodes[:5] * 20, initiator, DURATION, sender=initiator)
+
+    with ape.reverts("Invalid ritual duration"):
+        coordinator.initiateRitual(nodes, initiator, 0, sender=initiator)
 
     with ape.reverts("Providers must be sorted"):
-        coordinator.initiateRitual(nodes[1:] + [nodes[0]], sender=initiator)
+        coordinator.initiateRitual(nodes[1:] + [nodes[0]], initiator, DURATION, sender=initiator)
 
-    tx = coordinator.initiateRitual(nodes, sender=initiator)
+    with ape.reverts("ERC20: insufficient allowance"):
+        # Sender didn't approve enough tokens
+        coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
+
+
+def test_initiate_ritual(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    tx = coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
 
     events = list(coordinator.StartRitual.from_receipt(tx))
     assert len(events) == 1
@@ -73,8 +123,10 @@ def test_initiate_ritual(coordinator, nodes, initiator):
     assert coordinator.getRitualState(0) == RitualState.AWAITING_TRANSCRIPTS
 
 
-def test_post_transcript(coordinator, nodes, initiator):
-    coordinator.initiateRitual(nodes, sender=initiator)
+def test_post_transcript(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
 
     for node in nodes:
         assert coordinator.getRitualState(0) == RitualState.AWAITING_TRANSCRIPTS
@@ -97,21 +149,27 @@ def test_post_transcript(coordinator, nodes, initiator):
     assert coordinator.getRitualState(0) == RitualState.AWAITING_AGGREGATIONS
 
 
-def test_post_transcript_but_not_part_of_ritual(coordinator, nodes, initiator):
-    coordinator.initiateRitual(nodes, sender=initiator)
+def test_post_transcript_but_not_part_of_ritual(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
     with ape.reverts("Participant not part of ritual"):
         coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=initiator)
 
 
-def test_post_transcript_but_already_posted_transcript(coordinator, nodes, initiator):
-    coordinator.initiateRitual(nodes, sender=initiator)
+def test_post_transcript_but_already_posted_transcript(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
     coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[0])
     with ape.reverts("Node already posted transcript"):
         coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[0])
 
 
-def test_post_transcript_but_not_waiting_for_transcripts(coordinator, nodes, initiator):
-    coordinator.initiateRitual(nodes, sender=initiator)
+def test_post_transcript_but_not_waiting_for_transcripts(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
     for node in nodes:
         transcript = os.urandom(TRANSCRIPT_SIZE)
         coordinator.postTranscript(0, transcript, sender=node)
@@ -120,8 +178,10 @@ def test_post_transcript_but_not_waiting_for_transcripts(coordinator, nodes, ini
         coordinator.postTranscript(0, os.urandom(TRANSCRIPT_SIZE), sender=nodes[1])
 
 
-def test_post_aggregation(coordinator, nodes, initiator):
-    coordinator.initiateRitual(nodes, sender=initiator)
+def test_post_aggregation(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
+    cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
+    erc20.approve(coordinator.address, cost, sender=initiator)
+    coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
     transcript = os.urandom(TRANSCRIPT_SIZE)
     for node in nodes:
         coordinator.postTranscript(0, transcript, sender=node)
@@ -152,5 +212,4 @@ def test_post_aggregation(coordinator, nodes, initiator):
     assert len(events) == 1
     event = events[0]
     assert event["ritualId"] == 0
-    assert event["initiator"] == initiator.address
     assert event["successful"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -127,7 +127,7 @@ def test_post_aggregation(coordinator, nodes, initiator):
         coordinator.postTranscript(0, transcript, sender=node)
 
     aggregated = os.urandom(TRANSCRIPT_SIZE)
-    decryptionRequestStaticKeys = [os.urandom(58) for node in nodes]
+    decryptionRequestStaticKeys = [os.urandom(42) for node in nodes]
     publicKey = (os.urandom(32), os.urandom(16))
     for i, node in enumerate(nodes):
         assert coordinator.getRitualState(0) == RitualState.AWAITING_AGGREGATIONS

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -111,13 +111,14 @@ def test_invalid_initiate_ritual(coordinator, nodes, accounts, initiator):
 def test_initiate_ritual(coordinator, nodes, initiator, erc20, flat_rate_fee_model):
     cost = flat_rate_fee_model.getRitualInitiationCost(nodes, DURATION)
     erc20.approve(coordinator.address, cost, sender=initiator)
-    tx = coordinator.initiateRitual(nodes, initiator, DURATION, sender=initiator)
+    authority = initiator
+    tx = coordinator.initiateRitual(nodes, authority, DURATION, sender=initiator)
 
     events = list(coordinator.StartRitual.from_receipt(tx))
     assert len(events) == 1
     event = events[0]
     assert event["ritualId"] == 0
-    assert event["initiator"] == initiator
+    assert event["authority"] == authority
     assert event["participants"] == tuple(n.address.lower() for n in nodes)
 
     assert coordinator.getRitualState(0) == RitualState.AWAITING_TRANSCRIPTS

--- a/tests/test_subscription_manager.py
+++ b/tests/test_subscription_manager.py
@@ -7,7 +7,7 @@ INITIAL_FEE_RATE = Web3.to_wei(1, "gwei")
 
 @pytest.fixture(scope="module")
 def oz_dependency(project):
-    return project.dependencies["openzeppelin"]["4.8.1"]
+    return project.dependencies["openzeppelin"]["4.9.1"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This is an omnibus PR that addresses several pending functionalities for the Coordinator. From a subjective order of relevance:
1. Introduces **fee models**: initially we're just introducing here a basic `IFeeModel` interface that allows to calculate initiation costs, but that could be later extended to manage other payment inputs. For this PR, I'm instantiating the interface with a simple `FlatRateFeeModel`, where ritual initiation cost is just `dkg_size *  duration * rate` and the currency is assumed to be an ERC20 token. We also introduce `duration` as a parameter to initiate rituals.
2. Introduces an **access-controlled role for initiating rituals**, as well as a one-off switch to unleash ritual initiation. The proposed model works as follows:
    - Initially, Coordinator contract works in permissioned way (only addresses that have the `INITIATOR_ROLE` can create rituals)
    - This role can be granted by the Coordinator admin (uses OpenZeppelin access control model, see tests)
    - Admin can switch the Coordinator from permissioned to permissionless ritual initiation; at this point, the initiator role is not relevant anymore. Note that this action can't be undone.
    - Rationale for this model is that it both works for many types of deployments without changing the code:
         - It's the exact model we plan for the beta release (initially, ritual initiation is controlled by Threshold DAO but can be opened in the future)
         - For devnets and testnets, we have maximum flexibility: if we want it permissioned, we just grant initiator roles; if we want permissionless, we just call the switch.
3. Automatic **reimbursement of costs** for posting transcripts and aggregations. It uses Keep's ReimbursementPool model, currently in production with tBTCv2
4. Ensures that provided decryption request static key by nodes is 42 byte (courtesy of @derekpierre  🎸 )