### PR TITLE
Support increased number of nodes in coordinator tests

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -92,4 +92,4 @@ deployments:
 
 test:
   mnemonic: test test test test test test test test test test test junk
-  number_of_accounts: 15
+  number_of_accounts: 67

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -92,4 +92,4 @@ deployments:
 
 test:
   mnemonic: test test test test test test test test test test test junk
-  number_of_accounts: 67
+  number_of_accounts: 10


### PR DESCRIPTION
- Fixes `Providers not sorted` thrown in `test_coordinator.py` due to case-insensitive sorting of providers
- Based on #86 
- Need 2 reviews