### PR TITLE
Fix `conftest.py` attempting to use incorrect `openzeppelin` 

### DIFF
--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -35,7 +35,7 @@ PERCENTAGE_PENALTY_COEFFICIENT = 100000
 REWARD_DURATION = 60 * 60 * 24 * 7  # one week in seconds
 DEAUTHORIZATION_DURATION = 60 * 60 * 24 * 60  # 60 days in seconds
 
-DEPENDENCY = project.dependencies["openzeppelin"]["4.8.1"]
+DEPENDENCY = project.dependencies["openzeppelin"]["4.9.1"]
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Spotted in [GH Actions logs](https://github.com/nucypher/nucypher-contracts/actions/runs/5413879632/jobs/9840099311) after merging https://github.com/nucypher/nucypher-contracts/pull/86 