### PR TITLE
Yet another batch of improvements for Coordinator

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,10 +67,10 @@ jobs:
       - name: Install Solidity plugin for Prettier
         run: npm install prettier-plugin-solidity
 
-      - name: Solidty Lint
+      - name: Solidity Lint
         run: solhint 'contracts/**/*.sol'
 
-      - name: Python lint
+      - name: Python Lint
         uses: cclauss/GitHub-Action-for-pylint@0.7.0
         continue-on-error: true
         with:

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -105,7 +105,7 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         uint256 _feeRatePerSecond
     )
         AccessControlDefaultAdminRules(0, _admin)
-        FlatRateFeeModel(_currency, _feeRatePerSecond, _stakes)
+        FlatRateFeeModel(_currency, _feeRatePerSecond)
     {
         application = _stakes;
         timeout = _timeout;

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -61,12 +61,12 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         uint32 endTimestamp;
         uint16 totalTranscripts;
         uint16 totalAggregations;
-
+        //
         address authority;
         uint16 dkgSize;
         uint16 threshold;
         bool aggregationMismatch;
-
+        //
         IEncryptionAuthorizer accessController;
         BLS12381.G1Point publicKey;
         bytes aggregatedTranscript;
@@ -103,10 +103,7 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         address _admin,
         IERC20 _currency,
         uint256 _feeRatePerSecond
-    )
-        AccessControlDefaultAdminRules(0, _admin)
-        FlatRateFeeModel(_currency, _feeRatePerSecond)
-    {
+    ) AccessControlDefaultAdminRules(0, _admin) FlatRateFeeModel(_currency, _feeRatePerSecond) {
         application = _stakes;
         timeout = _timeout;
         maxDkgSize = _maxDkgSize;
@@ -229,7 +226,7 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         );
         uint16 length = uint16(providers.length);
         require(2 <= length && length <= maxDkgSize, "Invalid number of nodes");
-        require(duration >= 24 hours, "Invalid ritual duration");  // TODO: Define minimum duration #106
+        require(duration >= 24 hours, "Invalid ritual duration"); // TODO: Define minimum duration #106
 
         uint32 id = uint32(rituals.length);
         Ritual storage ritual = rituals.push();
@@ -355,9 +352,9 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
                 processPendingFee(ritualId);
                 // Register ritualId + 1 to discern ritualID#0 from unregistered keys.
                 // See getRitualIdFromPublicKey() for inverse operation.
-                bytes32 registryKey = keccak256(abi.encodePacked(
-                    BLS12381.g1PointToBytes(dkgPublicKey)
-                ));
+                bytes32 registryKey = keccak256(
+                    abi.encodePacked(BLS12381.g1PointToBytes(dkgPublicKey))
+                );
                 ritualPublicKeyRegistry[registryKey] = ritualId + 1;
                 emit EndRitual({ritualId: ritualId, successful: true});
             }
@@ -370,20 +367,16 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         BLS12381.G1Point memory dkgPublicKey
     ) external view returns (uint32 ritualId) {
         // If public key is not registered, result will produce underflow error
-        bytes32 registryKey = keccak256(abi.encodePacked(
-            BLS12381.g1PointToBytes(dkgPublicKey)
-        ));
+        bytes32 registryKey = keccak256(abi.encodePacked(BLS12381.g1PointToBytes(dkgPublicKey)));
         return ritualPublicKeyRegistry[registryKey] - 1;
     }
 
-    function getPublicKeyFromRitualId(uint32 ritualId) 
-    external view returns (BLS12381.G1Point memory dkgPublicKey) {
+    function getPublicKeyFromRitualId(
+        uint32 ritualId
+    ) external view returns (BLS12381.G1Point memory dkgPublicKey) {
         Ritual storage ritual = rituals[ritualId];
-        require(
-            getRitualState(ritual) == RitualState.FINALIZED,
-            "Ritual not finalized"
-        );
-       return ritual.publicKey;
+        require(getRitualState(ritual) == RitualState.FINALIZED, "Ritual not finalized");
+        return ritual.publicKey;
     }
 
     function getParticipantFromProvider(
@@ -441,7 +434,7 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
             // Refund everything minus cost of renting cohort for a day
             // TODO: Validate if this is enough to remove griefing attacks
             uint256 duration = ritual.endTimestamp - ritual.initTimestamp;
-            uint256 refundableFee = pending * (duration - 1 days) / duration;
+            uint256 refundableFee = (pending * (duration - 1 days)) / duration;
             currency.safeTransfer(ritual.initiator, refundableFee);
         }
     }
@@ -458,7 +451,7 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
     }
 
     function withdrawTokens(IERC20 token, uint256 amount) external onlyRole(TREASURY_ROLE) {
-        if (address(token) == address(currency)){
+        if (address(token) == address(currency)) {
             require(
                 amount <= token.balanceOf(address(this)) - totalPendingFees,
                 "Can't withdraw pending fees"

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -442,12 +442,10 @@ contract Coordinator is AccessControlDefaultAdminRules, FlatRateFeeModel {
         delete pendingFees[ritualId];
         // Transfer fees back to initiator if failed
         if (state == RitualState.TIMEOUT || state == RitualState.INVALID) {
-            // Amount to refund depends on how much work nodes did for the ritual.
+            // Refund everything minus cost of renting cohort for a day
             // TODO: Validate if this is enough to remove griefing attacks
-            uint256 executedTransactions = ritual.totalTranscripts + ritual.totalAggregations;
-            uint256 expectedTransactions = 2 * ritual.dkgSize;
-            uint256 consumedFee = (pending * executedTransactions) / expectedTransactions;
-            uint256 refundableFee = pending - consumedFee;
+            uint256 duration = ritual.endTimestamp - ritual.initTimestamp;
+            uint256 refundableFee = pending * (duration - 1 days) / duration;
             currency.safeTransfer(ritual.initiator, refundableFee);
         }
     }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -337,6 +337,7 @@ contract Coordinator is AccessControlDefaultAdminRules {
             keccak256(ritual.aggregatedTranscript) != aggregatedTranscriptDigest
         ) {
             ritual.aggregationMismatch = true;
+            delete ritual.publicKey;
             emit EndRitual({ritualId: ritualId, successful: false});
         }
 

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -227,7 +227,7 @@ contract Coordinator is AccessControlDefaultAdminRules {
         );
         uint16 length = uint16(providers.length);
         require(2 <= length && length <= maxDkgSize, "Invalid number of nodes");
-        require(duration > 0, "Invalid ritual duration"); // TODO: We probably want to restrict it more
+        require(duration >= 24 hours, "Invalid ritual duration");  // TODO: Define minimum duration #106
 
         uint32 id = uint32(rituals.length);
         Ritual storage ritual = rituals.push();

--- a/contracts/contracts/coordination/FlatRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlatRateFeeModel.sol
@@ -21,7 +21,7 @@ contract FlatRateFeeModel is IFeeModel {
     function getRitualInitiationCost(
         address[] calldata providers,
         uint32 duration
-    ) public view returns(uint256) {
+    ) public view returns (uint256) {
         uint256 size = providers.length;
         require(duration > 0, "Invalid ritual duration");
         require(size > 0, "Invalid ritual size");

--- a/contracts/contracts/coordination/FlatRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlatRateFeeModel.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @title FlatRateFeeModel
- * @notice FlateRateFeeModel
+ * @notice FlatRateFeeModel
  */
 contract FlatRateFeeModel is IFeeModel {
     IERC20 public immutable currency;

--- a/contracts/contracts/coordination/FlatRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlatRateFeeModel.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 import "./IFeeModel.sol";
-import "../../threshold/IAccessControlApplication.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
@@ -13,18 +12,16 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract FlatRateFeeModel is IFeeModel {
     IERC20 public immutable currency;
     uint256 public immutable feeRatePerSecond;
-    IAccessControlApplication public immutable stakes;
 
-    constructor(IERC20 _currency, uint256 _feeRatePerSecond, address _stakes) {
+    constructor(IERC20 _currency, uint256 _feeRatePerSecond) {
         currency = _currency;
         feeRatePerSecond = _feeRatePerSecond;
-        stakes = IAccessControlApplication(_stakes);
     }
 
     function getRitualInitiationCost(
         address[] calldata providers,
         uint32 duration
-    ) external view returns (uint256) {
+    ) public view returns(uint256) {
         uint256 size = providers.length;
         require(duration > 0, "Invalid ritual duration");
         require(size > 0, "Invalid ritual size");

--- a/contracts/contracts/coordination/GlobalAllowList.sol
+++ b/contracts/contracts/coordination/GlobalAllowList.sol
@@ -8,7 +8,7 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
     using ECDSA for bytes32;
 
     Coordinator public coordinator;
-    mapping(bytes32 => bool) authorizations;
+    mapping(bytes32 => bool) internal authorizations;
 
     constructor(
         Coordinator _coordinator,
@@ -25,7 +25,7 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
         _;
     }
 
-    function setCoordinator(Coordinator _coordinator) public onlyRole(DEFAULT_ADMIN_ROLE){
+    function setCoordinator(Coordinator _coordinator) public onlyRole(DEFAULT_ADMIN_ROLE) {
         require(address(_coordinator) != address(0), "Coordinator cannot be zero address");
         require(_coordinator.numberOfRituals() >= 0, "Invalid coordinator");
         coordinator = _coordinator;
@@ -63,11 +63,7 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
         setAuthorizations(ritualId, addresses, false);
     }
 
-    function setAuthorizations(
-        uint32 ritualId,
-        address[] calldata addresses,
-        bool value
-    ) internal {
+    function setAuthorizations(uint32 ritualId, address[] calldata addresses, bool value) internal {
         require(
             coordinator.isRitualFinalized(ritualId),
             "Only active rituals can add authorizations"

--- a/contracts/contracts/coordination/GlobalAllowList.sol
+++ b/contracts/contracts/coordination/GlobalAllowList.sol
@@ -35,8 +35,9 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
     function isAuthorized(
         uint32 ritualId,
         bytes memory evidence,
-        bytes32 digest
+        bytes memory ciphertextHeader
     ) public view override returns (bool) {
+        bytes32 digest = keccak256(ciphertextHeader);
         address recoveredAddress = digest.toEthSignedMessageHash().recover(evidence);
         return authorizations[ritualId][recoveredAddress];
     }

--- a/contracts/contracts/coordination/GlobalAllowList.sol
+++ b/contracts/contracts/coordination/GlobalAllowList.sol
@@ -14,9 +14,7 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
         Coordinator _coordinator,
         address _admin
     ) AccessControlDefaultAdminRules(0, _admin) {
-        require(address(_coordinator) != address(0), "Coordinator cannot be zero address");
-        require(_coordinator.numberOfRituals() >= 0, "Invalid coordinator");
-        coordinator = _coordinator;
+        setCoordinator(_coordinator);
     }
 
     modifier onlyAuthority(uint32 ritualId) {
@@ -27,8 +25,9 @@ contract GlobalAllowList is AccessControlDefaultAdminRules, IEncryptionAuthorize
         _;
     }
 
-    function setCoordinator(Coordinator _coordinator) public {
-        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Only admin can set coordinator");
+    function setCoordinator(Coordinator _coordinator) public onlyRole(DEFAULT_ADMIN_ROLE){
+        require(address(_coordinator) != address(0), "Coordinator cannot be zero address");
+        require(_coordinator.numberOfRituals() >= 0, "Invalid coordinator");
         coordinator = _coordinator;
     }
 

--- a/contracts/contracts/coordination/IEncryptionAuthorizer.sol
+++ b/contracts/contracts/coordination/IEncryptionAuthorizer.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 interface IEncryptionAuthorizer {
     function isAuthorized(
         uint32 ritualId,
-        bytes memory evidence,  // supporting evidence for authorization
-        bytes memory ciphertextHeader  // data to be signed by authorized
+        bytes memory evidence, // supporting evidence for authorization
+        bytes memory ciphertextHeader // data to be signed by authorized
     ) external view returns (bool);
 }

--- a/contracts/contracts/coordination/IEncryptionAuthorizer.sol
+++ b/contracts/contracts/coordination/IEncryptionAuthorizer.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.8.0;
 
 interface IEncryptionAuthorizer {
     function isAuthorized(
-        uint32 ritualID,
-        bytes memory evidence, // signature
-        bytes32 digest // signed message hash
+        uint32 ritualId,
+        bytes memory evidence,  // supporting evidence for authorization
+        bytes memory ciphertextHeader  // data to be signed by authorized
     ) external view returns (bool);
 }

--- a/contracts/contracts/coordination/IFeeModel.sol
+++ b/contracts/contracts/coordination/IFeeModel.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../../threshold/IAccessControlApplication.sol";
 
 /**
  * @title IFeeModel
@@ -11,8 +10,6 @@ import "../../threshold/IAccessControlApplication.sol";
  */
 interface IFeeModel {
     function currency() external view returns (IERC20);
-
-    function stakes() external view returns (IAccessControlApplication);
 
     function getRitualInitiationCost(
         address[] calldata providers,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -332,6 +332,10 @@ def test_authorize_using_global_allow_list(
         allow_logic=global_allow_list,
     )
 
+    access_control_error_message = f"AccessControl: account {initiator.address.lower()} is missing role 0x{'00'*32}"
+    with ape.reverts(access_control_error_message):
+        global_allow_list.setCoordinator(coordinator.address, sender=initiator)
+
     global_allow_list.setCoordinator(coordinator.address, sender=deployer)
 
     # This block mocks the signature of a threshold decryption request

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -369,16 +369,16 @@ def test_authorize_using_global_allow_list(
     global_allow_list.authorize(0, [deployer.address], sender=initiator)
 
     # Authorized
-    assert global_allow_list.isAuthorized(0, bytes(signature), bytes(digest))
+    assert global_allow_list.isAuthorized(0, bytes(signature), bytes(data))
 
     # Deauthorize
     global_allow_list.deauthorize(0, [deployer.address], sender=initiator)
-    assert not global_allow_list.isAuthorized(0, bytes(signature), bytes(digest))
+    assert not global_allow_list.isAuthorized(0, bytes(signature), bytes(data))
 
     # Reauthorize in batch
     addresses_to_authorize = [deployer.address, initiator.address]
     global_allow_list.authorize(0, addresses_to_authorize, sender=initiator)
     signed_digest = w3.eth.account.sign_message(signable_message, private_key=initiator.private_key)
     initiator_signature = signed_digest.signature
-    assert global_allow_list.isAuthorized(0, bytes(initiator_signature), bytes(digest))
-    assert global_allow_list.isAuthorized(0, bytes(signature), bytes(digest))
+    assert global_allow_list.isAuthorized(0, bytes(initiator_signature), bytes(data))
+    assert global_allow_list.isAuthorized(0, bytes(signature), bytes(data))


### PR DESCRIPTION
* Two-way mapping between successful rituals and TDec public keys.
* Consequently, invalidate stored TDec public keys if ritual fails (Closes #78)
* Store DKG threshold as part of ritual info, currently hard-coded to `1 + dkg size/2`. See https://github.com/nucypher/nucypher/issues/3095
* Define minimum ritual duration as 24 hours. See https://github.com/nucypher/nucypher-contracts/issues/106
* Simplify integration of `FeeModel` and `Coordinator`
* Optimize lookup table in `GlobalAllow` list (Closes #97)
* Define functionality and role to manage Coordinator funds
* Change `IEncryptionAuthorizer` API to require `ciphertext_header` instead of `digest`, to further strengthen verification.
* Assorted clean-up and test improvements