### PR TITLE
Implements multi-chain JSON registry data formatting

### DIFF
--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -17,7 +17,7 @@ ChainId = int
 ContractName = str
 
 
-class ContractEntry(NamedTuple):
+class RegistryEntry(NamedTuple):
     """Represents a single entry in a nucypher-style contract registry."""
     chain_id: ChainId
     name: ContractName
@@ -50,11 +50,11 @@ def _get_name(
 
 def _get_entry(
     contract_instance: ContractInstance, registry_names: Dict[ContractName, ContractName]
-) -> ContractEntry:
+) -> RegistryEntry:
     contract_abi = _get_abi(contract_instance)
     contract_name = _get_name(contract_instance=contract_instance, registry_names=registry_names)
     chain_id = contract_instance.chain_manager.chain_id
-    entry = ContractEntry(
+    entry = RegistryEntry(
         chain_id=chain_id,
         name=contract_name,
         address=to_checksum_address(contract_instance.address),
@@ -66,7 +66,7 @@ def _get_entry(
 def _get_entries(
         contract_instances: List[ContractInstance],
         registry_names: Dict[ContractName, ContractName]
-) -> List[ContractEntry]:
+) -> List[RegistryEntry]:
     """Returns a list of contract entries from a list of contract instances."""
     entries = list()
     for contract_instance in contract_instances:
@@ -78,13 +78,13 @@ def _get_entries(
     return entries
 
 
-def read_registry(filepath: Path) -> List[ContractEntry]:
+def read_registry(filepath: Path) -> List[RegistryEntry]:
     with open(filepath, "r") as file:
         data = json.load(file)
     registry_entries = list()
     for chain_id, entries in data.items():
         for contract_name, artifacts in entries.items():
-            registry_entry = ContractEntry(
+            registry_entry = RegistryEntry(
                 chain_id=int(chain_id),
                 name=contract_name,
                 address=artifacts["address"],
@@ -94,7 +94,7 @@ def read_registry(filepath: Path) -> List[ContractEntry]:
     return registry_entries
 
 
-def write_registry(entries: List[ContractEntry], filepath: Path) -> Path:
+def write_registry(entries: List[RegistryEntry], filepath: Path) -> Path:
     data = defaultdict(dict)
     for entry in entries:
         data[entry.chain_id][entry.name] = {
@@ -172,7 +172,7 @@ def merge_registries(
     reg1 = {e.name: e for e in read_registry(registry_1_filepath) if e.name not in deprecated_contracts}
     reg2 = {e.name: e for e in read_registry(registry_2_filepath) if e.name not in deprecated_contracts}
 
-    merged: List[ContractEntry] = list()
+    merged: List[RegistryEntry] = list()
 
     # Iterate over all unique contract names across both registries
     for name in set(reg1) | set(reg2):

--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -36,7 +36,7 @@ def _get_abi(contract_instance: ContractInstance) -> ABI:
 
 
 def _get_name(
-    contract_instance: ContractInstance, registry_names: Dict[ContractInstance, ContractName]
+    contract_instance: ContractInstance, registry_names: Dict[ContractName, ContractName]
 ) -> ContractName:
     """
     Returns the optionally remapped registry name of a contract instance.

--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -175,22 +175,20 @@ def merge_registries(
     merged: List[RegistryEntry] = list()
 
     # Iterate over all unique contract names across both registries
-    for name in set(reg1) | set(reg2):
-        entry = reg1.get(name) or reg2.get(name)
-        conflict_entry = reg2.get(name) if name in reg1 else None
-        conflict = conflict_entry and (entry.chain_id == conflict_entry.chain_id)
+    conflicts, contracts = set(reg1) & set(reg2), set(reg1) | set(reg2)
+    for name in contracts:
+        entry_1, entry_2 = reg1.get(name), reg2.get(name)
+        conflict = name in conflicts and entry_1.chain_id == entry_2.chain_id
         if conflict:
             resolution = _select_conflict_resolution(
-                registry_1_entry=entry,
-                registry_2_entry=conflict_entry,
+                registry_1_entry=entry_1,
+                registry_2_entry=entry_2,
                 registry_1_filepath=registry_1_filepath,
                 registry_2_filepath=registry_2_filepath
             )
-
-            # Choose the entry based on the resolution strategy
-            selected_entry = entry if resolution == ConflictResolution.USE_1 else conflict_entry
+            selected_entry = entry_1 if resolution == ConflictResolution.USE_1 else entry_2
         else:
-            selected_entry = entry
+            selected_entry = entry_1 or entry_2
 
         # commit the selected entry
         merged.append(selected_entry)

--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -51,7 +51,7 @@ def _get_name(
 
 
 def _get_entry(
-    contract_instance: ContractInstance, registry_names: Dict[ContractInstance, ContractName]
+    contract_instance: ContractInstance, registry_names: Dict[ContractName, ContractName]
 ) -> ContractEntry:
     contract_abi = _get_abi(contract_instance)
     contract_name = _get_name(contract_instance=contract_instance, registry_names=registry_names)


### PR DESCRIPTION
##### Requested Reviews
2

##### What this does

- Implements multi-chain JSON registry data format introduced in https://github.com/nucypher/nucypher/pull/3261
- Enriches type annotation and aliasing in `deployment/registry.py`
- Modifies `merge_registries` to include chain ID as part of conflict assessment criteria
- Optimizes registry merge utilities