### PR TITLE
Fix `merge_registries` to account for same contract names across different chain ids

### DIFF
--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -205,12 +205,12 @@ def merge_registries(
     for e in read_registry(registry_1_filepath):
         if e.name in deprecated_contracts:
             continue
-        reg1[str(e.chain_id)][e.name] = e
+        reg1[e.chain_id][e.name] = e
 
     for e in read_registry(registry_2_filepath):
         if e.name in deprecated_contracts:
             continue
-        reg2[str(e.chain_id)][e.name] = e
+        reg2[e.chain_id][e.name] = e
 
     merged: List[RegistryEntry] = list()
 
@@ -218,7 +218,7 @@ def merge_registries(
     all_chains = set(reg1) | set(reg2)
     common_chains = set(reg1) & set(reg2)
     for chain in all_chains:
-        reg1_chain_entries, reg2_chain_entries = reg1.get(str(chain), {}), reg2.get(str(chain), {})
+        reg1_chain_entries, reg2_chain_entries = reg1.get(chain, {}), reg2.get(chain, {})
         if chain in common_chains:
             # check for conflicting contracts
             all_contracts = set(reg1_chain_entries) | set(reg2_chain_entries)


### PR DESCRIPTION
It is possible to have the same contract name repeated across different chain ids. The initial set-up for the `merge_registries()` function placed all registry entries from a registry file into a dictionary keyed by name. However, some entries can get lost this way, because the dictionary is keyed by name and contract names can be repeated across different chains eg. `ProxyAdmin`. Therefore some registry entries don't end up in the merged contract registry.

This PR accounts for common names across the registry in different chains. The ridiculous test was to try to merge `lynx.json` and `tapir.json` (a ridiculous example yes, but great for testing). The merged registry should have all entries for chain id `5` from `lynx.json`, all entries from chain id `11155111` from `tapir.json` (those 2 chains are non-conflicting), and then conflicts for `80001` which you can test resolving appropriately. 

If the above test is run with the old code some registry entries (with dupe names across different chains) are not included for some chains. `ProxyAdmin` is the worst offender because it is an entry in all chains (`5`, `11155111`, `80001`).

Try it out, both with/without the change:
```bash
$ ape run merge_registries --registry-1 ./deployment/artifacts/lynx.json --registry-2 ./deployment/artifacts/tapir.json -o ./merge.json
```