### PR TITLE
Adds method to sample active staking providers using TACo child app

### DIFF
--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -653,24 +653,20 @@ contract TACoApplication is IApplication, ITACoChildToRoot, OwnableUpgradeable {
      * @param _maxStakingProviders Max providers for looking, if set 0 then all will be used
      * @return allAuthorizedTokens Sum of authorized tokens for active providers
      * @return activeStakingProviders Array of providers and their authorized tokens.
-     * Providers addresses stored as uint256
-     * @dev Note that activeStakingProviders[0] is an array of uint256, but you want addresses.
+     * Providers addresses stored together with amounts as bytes32
+     * @dev Note that activeStakingProviders is an array of bytes32, but you want addresses and amounts.
      * Careful when used directly!
      */
     function getActiveStakingProviders(
         uint256 _startIndex,
         uint256 _maxStakingProviders
-    )
-        external
-        view
-        returns (uint256 allAuthorizedTokens, uint256[2][] memory activeStakingProviders)
-    {
+    ) external view returns (uint256 allAuthorizedTokens, bytes32[] memory activeStakingProviders) {
         uint256 endIndex = stakingProviders.length;
         require(_startIndex < endIndex, "Wrong start index");
         if (_maxStakingProviders != 0 && _startIndex + _maxStakingProviders < endIndex) {
             endIndex = _startIndex + _maxStakingProviders;
         }
-        activeStakingProviders = new uint256[2][](endIndex - _startIndex);
+        activeStakingProviders = new bytes32[](endIndex - _startIndex);
         allAuthorizedTokens = 0;
 
         uint256 resultIndex = 0;
@@ -681,8 +677,11 @@ contract TACoApplication is IApplication, ITACoChildToRoot, OwnableUpgradeable {
             if (eligibleAmount < minimumAuthorization || !info.operatorConfirmed) {
                 continue;
             }
-            activeStakingProviders[resultIndex][0] = uint256(uint160(stakingProvider));
-            activeStakingProviders[resultIndex++][1] = eligibleAmount;
+            // bytes20 -> bytes32 adds padding after address: <address><12 zeros>
+            // uint96 -> uint256 adds padding before uint96: <20 zeros><amount>
+            activeStakingProviders[resultIndex++] =
+                bytes32(bytes20(stakingProvider)) |
+                bytes32(uint256(eligibleAmount));
             allAuthorizedTokens += eligibleAmount;
         }
         assembly {

--- a/contracts/contracts/coordination/TACoChildApplication.sol
+++ b/contracts/contracts/coordination/TACoChildApplication.sol
@@ -16,10 +16,9 @@ import "./Coordinator.sol";
 contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initializable {
     struct StakingProviderInfo {
         address operator;
-        bool operatorConfirmed;
         uint96 authorized;
-        // TODO: what about undelegations etc?
-        uint256 index; // index in stakingProviders array + 1
+        bool operatorConfirmed;
+        uint248 index; // index in stakingProviders array + 1
     }
 
     ITACoChildToRoot public immutable rootApplication;
@@ -91,7 +90,7 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
 
         if (info.index == 0) {
             stakingProviders.push(stakingProvider);
-            info.index = stakingProviders.length;
+            info.index = uint248(stakingProviders.length);
         }
 
         info.operator = operator;

--- a/tests/application/test_operator.py
+++ b/tests/application/test_operator.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import ape
 from ape.utils import ZERO_ADDRESS
-from eth_utils import to_checksum_address
+from eth_utils import to_checksum_address, to_int
 from web3 import Web3
 
 CONFIRMATION_SLOT = 1
@@ -122,8 +122,8 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
     assert all_locked == min_authorization
     assert len(staking_providers) == 1
-    assert to_checksum_address(staking_providers[0][0]) == staking_provider_3
-    assert staking_providers[0][1] == min_authorization
+    assert to_checksum_address(staking_providers[0][0:20]) == staking_provider_3
+    assert to_int(staking_providers[0][20:32]) == min_authorization
 
     # Operator is in use so other stakingProviders can't bond him
     with ape.reverts():
@@ -322,10 +322,10 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
     assert all_locked == 2 * min_authorization
     assert len(staking_providers) == 2
-    assert to_checksum_address(staking_providers[0][0]) == staking_provider_3
-    assert staking_providers[0][1] == min_authorization
-    assert to_checksum_address(staking_providers[1][0]) == staking_provider_1
-    assert staking_providers[1][1] == min_authorization
+    assert to_checksum_address(staking_providers[0][0:20]) == staking_provider_3
+    assert to_int(staking_providers[0][20:32]) == min_authorization
+    assert to_checksum_address(staking_providers[1][0:20]) == staking_provider_1
+    assert to_int(staking_providers[1][20:32]) == min_authorization
     threshold_staking.involuntaryAuthorizationDecrease(
         staking_provider_1, min_authorization, min_authorization - 1, sender=creator
     )

--- a/tests/test_child_application.py
+++ b/tests/test_child_application.py
@@ -21,7 +21,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 
 OPERATOR_SLOT = 0
-CONFIRMATION_SLOT = 1
+CONFIRMATION_SLOT = 2
 
 MIN_AUTHORIZATION = Web3.to_wei(40_000, "ether")
 

--- a/tests/test_child_application.py
+++ b/tests/test_child_application.py
@@ -17,6 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import ape
 import pytest
 from ape.utils import ZERO_ADDRESS
+from eth_utils import to_checksum_address
 from web3 import Web3
 
 OPERATOR_SLOT = 0
@@ -77,10 +78,16 @@ def test_update_operator(accounts, root_application, child_application):
     assert child_application.stakingProviderFromOperator(operator_1) == staking_provider_1
     assert child_application.stakingProviderInfo(staking_provider_1)[OPERATOR_SLOT] == operator_1
     assert not child_application.stakingProviderInfo(staking_provider_1)[CONFIRMATION_SLOT]
+    assert child_application.getStakingProvidersLength() == 1
 
     assert tx.events == [
         child_application.OperatorUpdated(stakingProvider=staking_provider_1, operator=operator_1)
     ]
+
+    # No active stakingProviders before confirmation
+    all_locked, staking_providers = child_application.getActiveStakingProviders(0, 0)
+    assert all_locked == 0
+    assert len(staking_providers) == 0
 
     # Rebond operator
     tx = root_application.updateOperator(staking_provider_1, operator_2, sender=creator)
@@ -89,6 +96,7 @@ def test_update_operator(accounts, root_application, child_application):
     assert child_application.stakingProviderInfo(staking_provider_1)[OPERATOR_SLOT] == operator_2
     assert not child_application.stakingProviderInfo(operator_2)[CONFIRMATION_SLOT]
     assert not child_application.stakingProviderInfo(operator_1)[CONFIRMATION_SLOT]
+    assert child_application.getStakingProvidersLength() == 1
 
     assert tx.events == [
         child_application.OperatorUpdated(stakingProvider=staking_provider_1, operator=operator_2)
@@ -100,6 +108,7 @@ def test_update_operator(accounts, root_application, child_application):
     assert child_application.stakingProviderInfo(staking_provider_1)[OPERATOR_SLOT] == ZERO_ADDRESS
     assert not child_application.stakingProviderInfo(operator_2)[CONFIRMATION_SLOT]
     assert child_application.stakingProviderFromOperator(ZERO_ADDRESS) == ZERO_ADDRESS
+    assert child_application.getStakingProvidersLength() == 1
 
     assert tx.events == [
         child_application.OperatorUpdated(stakingProvider=staking_provider_1, operator=ZERO_ADDRESS)
@@ -110,6 +119,7 @@ def test_update_operator(accounts, root_application, child_application):
     assert child_application.stakingProviderFromOperator(operator_1) == staking_provider_2
     assert child_application.stakingProviderInfo(staking_provider_2)[OPERATOR_SLOT] == operator_1
     assert not child_application.stakingProviderInfo(operator_1)[CONFIRMATION_SLOT]
+    assert child_application.getStakingProvidersLength() == 2
 
     assert tx.events == [
         child_application.OperatorUpdated(stakingProvider=staking_provider_2, operator=operator_1)
@@ -154,7 +164,14 @@ def test_update_authorization(accounts, root_application, child_application):
 
 
 def test_confirm_address(accounts, root_application, child_application, coordinator):
-    creator, staking_provider, operator, *everyone_else = accounts[0:]
+    (
+        creator,
+        staking_provider,
+        operator,
+        other_staking_provier,
+        other_operator,
+        *everyone_else,
+    ) = accounts[0:]
     value = Web3.to_wei(40_000, "ether")
 
     # Call to confirm operator address can be done only from coordinator
@@ -170,6 +187,7 @@ def test_confirm_address(accounts, root_application, child_application, coordina
     assert child_application.stakingProviderFromOperator(operator) == staking_provider
     assert child_application.stakingProviderInfo(staking_provider)[OPERATOR_SLOT] == operator
     assert not child_application.stakingProviderInfo(staking_provider)[CONFIRMATION_SLOT]
+    assert child_application.getStakingProvidersLength() == 1
 
     # Can't confirm operator address without authorized amount
     with ape.reverts("Authorization must be greater than minimum"):
@@ -189,14 +207,55 @@ def test_confirm_address(accounts, root_application, child_application, coordina
         child_application.OperatorConfirmed(stakingProvider=staking_provider, operator=operator)
     ]
 
+    # After confirmation operator is becoming active
+    all_locked, staking_providers = child_application.getActiveStakingProviders(0, 0)
+    assert all_locked == value
+    assert len(staking_providers) == 1
+    assert to_checksum_address(staking_providers[0][0]) == staking_provider
+    assert staking_providers[0][1] == value
+
     # Can't confirm twice
     with ape.reverts("Can't confirm same operator twice"):
         coordinator.confirmOperatorAddress(operator, sender=creator)
 
+    # Confirm another operator
+    root_application.updateAuthorization(other_staking_provier, value, sender=creator)
+    root_application.updateOperator(other_staking_provier, other_staking_provier, sender=creator)
+    coordinator.confirmOperatorAddress(other_staking_provier, sender=creator)
+    assert child_application.stakingProviderInfo(other_staking_provier)[CONFIRMATION_SLOT]
+    assert root_application.confirmations(other_staking_provier)
+    assert child_application.getStakingProvidersLength() == 2
+
+    # After confirmation operator is becoming active
+    all_locked, staking_providers = child_application.getActiveStakingProviders(0, 0)
+    assert all_locked == 2 * value
+    assert len(staking_providers) == 2
+    assert to_checksum_address(staking_providers[0][0]) == staking_provider
+    assert to_checksum_address(staking_providers[1][0]) == other_staking_provier
+    assert staking_providers[0][1] == value
+    assert staking_providers[1][1] == value
+    all_locked, staking_providers = child_application.getActiveStakingProviders(1, 1)
+    assert all_locked == value
+    assert len(staking_providers) == 1
+    assert to_checksum_address(staking_providers[0][0]) == other_staking_provier
+    assert staking_providers[0][1] == value
+
     # Changing operator resets confirmation
-    root_application.updateOperator(staking_provider, staking_provider, sender=creator)
-    assert child_application.stakingProviderFromOperator(staking_provider) == staking_provider
+    root_application.updateOperator(other_staking_provier, other_operator, sender=creator)
+    assert child_application.stakingProviderFromOperator(other_operator) == other_staking_provier
     assert (
-        child_application.stakingProviderInfo(staking_provider)[OPERATOR_SLOT] == staking_provider
+        child_application.stakingProviderInfo(other_staking_provier)[OPERATOR_SLOT]
+        == other_operator
     )
-    assert not child_application.stakingProviderInfo(staking_provider)[CONFIRMATION_SLOT]
+    assert not child_application.stakingProviderInfo(other_staking_provier)[CONFIRMATION_SLOT]
+    assert child_application.getStakingProvidersLength() == 2
+
+    # Resetting operator removes from active list before next confirmation
+    all_locked, staking_providers = child_application.getActiveStakingProviders(1, 0)
+    assert all_locked == 0
+    assert len(staking_providers) == 0
+
+    root_application.updateAuthorization(staking_provider, value - 1, sender=creator)
+    all_locked, staking_providers = child_application.getActiveStakingProviders(0, 0)
+    assert all_locked == 0
+    assert len(staking_providers) == 0


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Adds `getActiveStakingProviders` to `TACoChildApplication`

**Why it's needed:**
This method works using operator confirmations, and confirmations use bridge from polygon to mainnet. This direction needs bot or changes in dashboard. To decrease priority for that direction we can use child app for sampling

