### PR TITLE
Bump version: 0.10.0 → 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/nucypher-contracts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "AGPL-3.0-or-later",
   "description": "Threshold Access Control (TACo) Smart Contracts",
   "author": "NuCypher",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?


### PR DESCRIPTION
Bump patch after [bugfix](https://github.com/nucypher/nucypher-contracts/commit/123de8e183accf761463eeb747a409a6a1fdbcb2) from @piotr-roslaniec 