### PR TITLE
Last minute changes to Coordinator

### DIFF
--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -254,6 +254,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         ritual.endTimestamp = ritual.initTimestamp + duration;
         ritual.accessController = accessController;
 
+        uint96 minAuthorization = application.minimumAuthorization();
         address previous = address(0);
         for (uint256 i = 0; i < length; i++) {
             Participant storage newParticipant = ritual.participant.push();
@@ -265,7 +266,10 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             require(previous < current, "Providers must be sorted");
             // TODO: Improve check for eligible nodes (staking, etc) - nucypher#3109
             // TODO: Change check to isAuthorized(), without amount
-            require(application.authorizedStake(current) > 0, "Not enough authorization");
+            require(
+                application.authorizedStake(current) >= minAuthorization, 
+                "Not enough authorization"
+            );
             newParticipant.provider = current;
             previous = current;
         }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -124,6 +124,17 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return getRitualState(rituals[ritualId]) == RitualState.FINALIZED;
     }
 
+    function isRitualActive(Ritual storage ritual) internal view returns (bool) {
+        bool dkgIsFinalized = getRitualState(ritual) == RitualState.FINALIZED;
+        bool ritualIsNotExpired = block.timestamp <= ritual.endTimestamp;
+        return dkgIsFinalized && ritualIsNotExpired;
+    }
+
+    function isRitualActive(uint32 ritualId) external view returns (bool) {
+        Ritual storage ritual = rituals[ritualId];
+        return isRitualActive(ritual);
+    }
+
     function getRitualState(Ritual storage ritual) internal view returns (RitualState) {
         uint32 t0 = ritual.initTimestamp;
         uint32 deadline = t0 + timeout;

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -33,6 +33,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     // Admin
     event TimeoutChanged(uint32 oldTimeout, uint32 newTimeout);
     event MaxDkgSizeChanged(uint16 oldSize, uint16 newSize);
+    event ReimbursementPoolSet(address indexed pool);
 
     event ParticipantPublicKeySet(
         uint32 indexed ritualId,
@@ -203,7 +204,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             "Invalid ReimbursementPool"
         );
         reimbursementPool = pool;
-        // TODO: Events
+        emit ReimbursementPoolSet(address(pool));
     }
 
     function setRitualAuthority(uint32 ritualId, address authority) external {

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -141,7 +141,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             return RitualState.NON_INITIATED;
         } else if (ritual.totalAggregations == ritual.dkgSize) {
             // DKG was succesful
-            if(block.timestamp <= ritual.endTimestamp) {
+            if (block.timestamp <= ritual.endTimestamp) {
                 return RitualState.ACTIVE;
             } else {
                 return RitualState.EXPIRED;
@@ -287,7 +287,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             // TODO: Improve check for eligible nodes (staking, etc) - nucypher#3109
             // TODO: Change check to isAuthorized(), without amount
             require(
-                application.authorizedStake(current) >= minAuthorization, 
+                application.authorizedStake(current) >= minAuthorization,
                 "Not enough authorization"
             );
             newParticipant.provider = current;
@@ -417,8 +417,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         Ritual storage ritual = rituals[ritualId];
         RitualState state = getRitualState(ritual);
         require(
-            state == RitualState.ACTIVE
-            || state == RitualState.EXPIRED,
+            state == RitualState.ACTIVE || state == RitualState.EXPIRED,
             "Ritual not finalized"
         );
         return ritual.publicKey;
@@ -468,7 +467,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         currency.safeTransferFrom(msg.sender, address(this), ritualCost);
     }
 
-    function processPendingFee(uint32 ritualId) public returns(uint256){
+    function processPendingFee(uint32 ritualId) public returns (uint256) {
         Ritual storage ritual = rituals[ritualId];
         RitualState state = getRitualState(ritual);
         require(

--- a/contracts/contracts/coordination/GlobalAllowList.sol
+++ b/contracts/contracts/coordination/GlobalAllowList.sol
@@ -62,10 +62,7 @@ contract GlobalAllowList is IEncryptionAuthorizer {
     }
 
     function setAuthorizations(uint32 ritualId, address[] calldata addresses, bool value) internal {
-        require(
-            coordinator.isRitualActive(ritualId),
-            "Only active rituals can add authorizations"
-        );
+        require(coordinator.isRitualActive(ritualId), "Only active rituals can add authorizations");
         for (uint256 i = 0; i < addresses.length; i++) {
             authorizations[lookupKey(ritualId, addresses[i])] = value;
         }

--- a/contracts/contracts/coordination/GlobalAllowList.sol
+++ b/contracts/contracts/coordination/GlobalAllowList.sol
@@ -63,7 +63,7 @@ contract GlobalAllowList is IEncryptionAuthorizer {
 
     function setAuthorizations(uint32 ritualId, address[] calldata addresses, bool value) internal {
         require(
-            coordinator.isRitualFinalized(ritualId),
+            coordinator.isRitualActive(ritualId),
             "Only active rituals can add authorizations"
         );
         for (uint256 i = 0; i < addresses.length; i++) {

--- a/contracts/test/CoordinatorTestSet.sol
+++ b/contracts/test/CoordinatorTestSet.sol
@@ -8,6 +8,9 @@ import "../threshold/ITACoChildApplication.sol";
  * @notice Contract for testing Coordinator contract
  */
 contract ChildApplicationForCoordinatorMock is ITACoChildApplication {
+
+    uint96 public constant minimumAuthorization = 0;
+
     mapping(address => uint96) public authorizedStake;
     mapping(address => address) public operatorFromStakingProvider;
     mapping(address => address) public stakingProviderFromOperator;

--- a/contracts/test/CoordinatorTestSet.sol
+++ b/contracts/test/CoordinatorTestSet.sol
@@ -8,8 +8,7 @@ import "../threshold/ITACoChildApplication.sol";
  * @notice Contract for testing Coordinator contract
  */
 contract ChildApplicationForCoordinatorMock is ITACoChildApplication {
-
-    uint96 public constant minimumAuthorization = 0;
+    uint96 public minimumAuthorization = 0;
 
     mapping(address => uint96) public authorizedStake;
     mapping(address => address) public operatorFromStakingProvider;

--- a/contracts/threshold/ITACoChildApplication.sol
+++ b/contracts/threshold/ITACoChildApplication.sol
@@ -9,5 +9,6 @@ interface ITACoChildApplication is ITACoChildToRoot {
 
     function authorizedStake(address _stakingProvider) external view returns (uint96);
 
+    function minimumAuthorization() external view returns (uint96);
     //TODO: Function to get locked stake duration?
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nucypher/nucypher-contracts",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nucypher/nucypher-contracts",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.9.0",


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
* Main change in the contract was refactoring `RitualState` to allow discerning active and expired rituals at the protocol state level.
* Introduces some missing events (see #178)
* Enforces minimum stake of providers during ritual initiation
* Additional tests

Related PRs:
- Sister PR in nucypher/nucypher - https://github.com/nucypher/nucypher/pull/3344
- Brother PR in `nucypher/taco-web` (nee `nucypher-ts`) - https://github.com/nucypher/taco-web/pull/398

**Issues fixed/closed:**
- Fixes #178

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?