### PR TITLE
Revamped lynx contract deployment

### DIFF
--- a/contracts/contracts/testnet/LynxSet.sol
+++ b/contracts/contracts/testnet/LynxSet.sol
@@ -68,22 +68,6 @@ contract MockPolygonChild is Ownable, ITACoChildToRoot, ITACoRootToChild {
     function confirmOperatorAddress(address _operator) external override {}
 }
 
-contract LynxTACoChildApplication is TACoChildApplication, Ownable {
-    constructor(
-        ITACoChildToRoot _rootApplication,
-        uint96 _minimumAuthorization
-    ) TACoChildApplication(_rootApplication, _minimumAuthorization) Ownable(msg.sender) {}
-
-    function setCoordinator(address _coordinator) external onlyOwner {
-        require(_coordinator != address(0), "Coordinator must be specified");
-        require(
-            address(Coordinator(_coordinator).application()) == address(this),
-            "Invalid coordinator"
-        );
-        coordinator = _coordinator;
-    }
-}
-
 contract LynxRitualToken is ERC20("LynxRitualToken", "LRT") {
     constructor(uint256 _totalSupplyOfTokens) {
         _mint(msg.sender, _totalSupplyOfTokens);

--- a/deployment/artifacts/lynx.json
+++ b/deployment/artifacts/lynx.json
@@ -1,5956 +1,5259 @@
 {
-    "80001": {
-        "OpenAccessAuthorizer": {
-            "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
-            "abi": [
-                {
-                    "type": "function",
-                    "name": "isAuthorized",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
-            "block_number": 41671721,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+  "80001": {
+    "MockPolygonChild": {
+      "address": "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
+      "abi": [
+        {
+          "type": "event",
+          "name": "AuthorizationUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
         },
-        "Coordinator": {
-            "address": "0x8E49989F9D3aD89c8ab0de21FbA2E00C67ca872F",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_application",
-                            "type": "address",
-                            "internalType": "contract ITACoChildApplication"
-                        },
-                        {
-                            "name": "_timeout",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "_maxDkgSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "_admin",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_currency",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        },
-                        {
-                            "name": "_feeRatePerSecond",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AggregationPosted",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "node",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "aggregatedTranscriptDigest",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeScheduled",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        },
-                        {
-                            "name": "effectSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferScheduled",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "acceptSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "EndRitual",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "successful",
-                            "type": "bool",
-                            "internalType": "bool",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "MaxDkgSizeChanged",
-                    "inputs": [
-                        {
-                            "name": "oldSize",
-                            "type": "uint16",
-                            "internalType": "uint16",
-                            "indexed": false
-                        },
-                        {
-                            "name": "newSize",
-                            "type": "uint16",
-                            "internalType": "uint16",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "ParticipantPublicKeySet",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "participant",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleAdminChanged",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "previousAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleGranted",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleRevoked",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "StartAggregationRound",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "StartRitual",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "participants",
-                            "type": "address[]",
-                            "internalType": "address[]",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "TimeoutChanged",
-                    "inputs": [
-                        {
-                            "name": "oldTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": false
-                        },
-                        {
-                            "name": "newTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "TranscriptPosted",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "node",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "transcriptDigest",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "INITIATOR_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "TREASURY_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "acceptDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "application",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildApplication"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "beginDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "cancelDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "changeDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "cohortFingerprint",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "nodes",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "currency",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelayIncreaseWait",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "feeRatePerSecond",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getAuthority",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipantFromProvider",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipants",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProviderPublicKey",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_provider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_ritualId",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getPublicKeyFromRitualId",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "dkgPublicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualIdFromPublicKey",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "dkgPublicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualInitiationCost",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualState",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8",
-                            "internalType": "enum Coordinator.RitualState"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRoleAdmin",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getThresholdForRitualSize",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "size",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "grantRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "hasRole",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initiateRitual",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isEncryptionAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "evidence",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "ciphertextHeader",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isInitiationPublic",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isProviderPublicKeySet",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_provider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isRitualFinalized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "makeInitiationPublic",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "maxDkgSize",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "numberOfRituals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingFees",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "postAggregation",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "aggregatedTranscript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "dkgPublicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        },
-                        {
-                            "name": "decryptionRequestStaticKey",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "postTranscript",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "transcript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "processPendingFee",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "renounceRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "revokeRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rituals",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "initiator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "initTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "endTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "totalTranscripts",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "totalAggregations",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "dkgSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "threshold",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "aggregationMismatch",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        },
-                        {
-                            "name": "publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        },
-                        {
-                            "name": "aggregatedTranscript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rollbackDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setMaxDkgSize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setProviderPublicKey",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setReimbursementPool",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "pool",
-                            "type": "address",
-                            "internalType": "contract IReimbursementPool"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setRitualAuthority",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setTimeout",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "supportsInterface",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "interfaceId",
-                            "type": "bytes4",
-                            "internalType": "bytes4"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "timeout",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "totalPendingFees",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "withdrawTokens",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "token",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x6495205ffa4f622cef2824c31b615812934379db8a6766e345881f5ac635f237",
-            "block_number": "40514266",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "event",
+          "name": "OperatorConfirmed",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
         },
-        "LynxTACoChildApplication": {
-            "address": "0x6e8307390c3a24024de31cc2E48Df41aC094823D",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_rootApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Initialized",
-                    "inputs": [
-                        {
-                            "name": "version",
-                            "type": "uint8",
-                            "internalType": "uint8",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedStake",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initialize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rootApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "setCoordinator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderFromOperator",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderInfo",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operatorConfirmed",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "authorized",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x2828463e3affc523f7e2a827b442afa8dbe07622359d3b51364a50aa357170a7",
-            "block_number": "40514217",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "event",
+          "name": "OperatorUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
         },
-        "SubscriptionManager": {
-            "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
-            "abi": [
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "oldFeeRate",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "newFeeRate",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "FeeRateUpdated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes16",
-                            "name": "policyId",
-                            "type": "bytes16"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sponsor",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "owner",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint16",
-                            "name": "size",
-                            "type": "uint16"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "endTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "cost",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "PolicyCreated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "previousAdminRole",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "newAdminRole",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "RoleAdminChanged",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleGranted",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleRevoked",
-                    "type": "event"
-                },
-                {
-                    "inputs": [],
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "SET_RATE_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "WITHDRAW_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyId",
-                            "type": "bytes16"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "_policyOwner",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
-                    "name": "createPolicy",
-                    "outputs": [],
-                    "stateMutability": "payable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "feeRate",
-                    "outputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
-                        }
-                    ],
-                    "name": "getPolicy",
-                    "outputs": [
-                        {
-                            "components": [
-                                {
-                                    "internalType": "address payable",
-                                    "name": "sponsor",
-                                    "type": "address"
-                                },
-                                {
-                                    "internalType": "uint32",
-                                    "name": "startTimestamp",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "internalType": "uint32",
-                                    "name": "endTimestamp",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "internalType": "uint16",
-                                    "name": "size",
-                                    "type": "uint16"
-                                },
-                                {
-                                    "internalType": "address",
-                                    "name": "owner",
-                                    "type": "address"
-                                }
-                            ],
-                            "internalType": "struct SubscriptionManager.Policy",
-                            "name": "",
-                            "type": "tuple"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
-                    "name": "getPolicyCost",
-                    "outputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "getRoleAdmin",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "grantRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "hasRole",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "_feeRate",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "initialize",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
-                        }
-                    ],
-                    "name": "isPolicyActive",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "renounceRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "revokeRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "_ratePerSecond",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "setFeeRate",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes4",
-                            "name": "interfaceId",
-                            "type": "bytes4"
-                        }
-                    ],
-                    "name": "supportsInterface",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "address payable",
-                            "name": "recipient",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "sweep",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                }
-            ],
-            "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
-            "block_number": "25203956",
-            "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
         },
-        "ProxyAdmin": {
-            "address": "0xC1a87ED2FEEa048eB69EBB6e033757EF7a837Ea9",
-            "abi": [
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "changeProxyAdmin",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "getProxyAdmin",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProxyImplementation",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "upgrade",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "implementation",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "upgradeAndCall",
-                    "stateMutability": "payable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "implementation",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "data",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x4848b47252d716f430e40dce6edd5c03bb6de97b0fae83d5a62749364a788fcb",
-            "block_number": "40514196",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "function",
+          "name": "childApplication",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITACoRootToChild"
+            }
+          ]
         },
-        "MockPolygonChild": {
-            "address": "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
-            "abi": [
-                {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "childApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setChildApplication",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_childApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x05c20dd9661b89048e50304d6b4cf626167c44bb64b0137aeb88155d277b9c94",
-            "block_number": "40514106",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "function",
+          "name": "confirmOperatorAddress",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
         },
-        "GlobalAllowList": {
-            "address": "0x7b521E78CFaf55fa01433181d1D636E7e4b73243",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        },
-                        {
-                            "name": "_admin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeScheduled",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        },
-                        {
-                            "name": "effectSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferScheduled",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "acceptSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleAdminChanged",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "previousAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleGranted",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleRevoked",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "acceptDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "authorize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "addresses",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "beginDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "cancelDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "changeDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "deauthorize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "addresses",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelayIncreaseWait",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRoleAdmin",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "grantRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "hasRole",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isAddressAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "encryptor",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "evidence",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "ciphertextHeader",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "revokeRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rollbackDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setCoordinator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "supportsInterface",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "interfaceId",
-                            "type": "bytes4",
-                            "internalType": "bytes4"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x0a38767055d1e20a625321c1a12d7e4a2c3da05c2922cdf815d154491d86b8e8",
-            "block_number": "40514285",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "function",
+          "name": "owner",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
         },
-        "TACoChildApplication": {
-            "address": "0x55A25dff1b38Ec76E2a1A8E42f2728c7347fdF4a",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_rootApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Initialized",
-                    "inputs": [
-                        {
-                            "name": "version",
-                            "type": "uint8",
-                            "internalType": "uint8",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedStake",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initialize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rootApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "setCoordinator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderFromOperator",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderInfo",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operatorConfirmed",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "authorized",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x2e057cb2cdcba579d9337a4775883faafbbae9bb1fab79f20aabcf3ab83d69d7",
-            "block_number": "40514226",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
         },
-        "LynxRitualToken": {
-            "address": "0x6DED3A2DCaC9dcB62253F063D765F323D6E4be82",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_totalSupplyOfTokens",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "Approval",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Transfer",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "allowance",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "approve",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "balanceOf",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decimals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8",
-                            "internalType": "uint8"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decreaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "subtractedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "increaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "addedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "name",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "symbol",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "totalSupply",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferFrom",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x01457fcb28352bfb2cf6f39871f2de00601122cdf7c7a5a0e98fccea88b16b60",
-            "block_number": "40514238",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "function",
+          "name": "setChildApplication",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_childApplication",
+              "type": "address",
+              "internalType": "contract ITACoRootToChild"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "updateAuthorization",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "updateOperator",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
         }
+      ],
+      "tx_hash": "0x05c20dd9661b89048e50304d6b4cf626167c44bb64b0137aeb88155d277b9c94",
+      "block_number": "40514106",
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
     },
-    "5": {
-        "LynxStakingToken": {
-            "address": "0x90990F1F7C952D4D02759802565d62479e8aA936",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_totalSupplyOfTokens",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "Approval",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Transfer",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "allowance",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "approve",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "balanceOf",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decimals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8",
-                            "internalType": "uint8"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decreaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "subtractedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "increaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "addedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "name",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "symbol",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "totalSupply",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferFrom",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x727721ea135cd46bc4510b163b524672cf5eed2df1bcdef8886b775d883a34a3",
-            "block_number": "9758692",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    "Coordinator": {
+      "address": "0x530608219a8A671FD183534b17E2a2CE09e782a4",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_application",
+              "type": "address",
+              "internalType": "contract ITACoChildApplication"
+            },
+            {
+              "name": "_currency",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "_feeRatePerSecond",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
         },
-        "ProxyAdmin": {
-            "address": "0x3e1E113A6d6D8e15e4F9d71D3144339E205410af",
-            "abi": [
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "changeProxyAdmin",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "getProxyAdmin",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProxyImplementation",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "upgrade",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "implementation",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "upgradeAndCall",
-                    "stateMutability": "payable",
-                    "inputs": [
-                        {
-                            "name": "proxy",
-                            "type": "address",
-                            "internalType": "contract ITransparentUpgradeableProxy"
-                        },
-                        {
-                            "name": "implementation",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "data",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x0b793809733fc8367c29e2e6fba0bbaed6f75bf3900841a96e9b32e0f79f7c4e",
-            "block_number": "9758700",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "error",
+          "name": "AccessControlBadConfirmation",
+          "inputs": []
         },
-        "TestnetThresholdStaking": {
-            "address": "0xcdD63981c8f4a2A684d102f7d7693A1c326CDd33",
-            "abi": [
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "application",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IApplication"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "authorizationIncreased",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedStake",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rolesOf",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "beneficiary",
-                            "type": "address",
-                            "internalType": "address payable"
-                        },
-                        {
-                            "name": "authorizer",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "setApplication",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_application",
-                            "type": "address",
-                            "internalType": "contract IApplication"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setRoles",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setRoles",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_beneficiary",
-                            "type": "address",
-                            "internalType": "address payable"
-                        },
-                        {
-                            "name": "_authorizer",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setStakes",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_tStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_keepInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_nuInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "stakedNu",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakes",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "tStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "keepInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "nuInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderInfo",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "beneficiary",
-                            "type": "address",
-                            "internalType": "address payable"
-                        },
-                        {
-                            "name": "authorizer",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "tStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "keepInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "nuInTStake",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x1d2bd03c0a9204b8ec1aae6f10eed732699d91da7fe66e20adf154259fdff027",
-            "block_number": "9758696",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "error",
+          "name": "AccessControlEnforcedDefaultAdminDelay",
+          "inputs": [
+            {
+              "name": "schedule",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ]
         },
-        "TransparentUpgradeableProxy": {
-            "address": "0x40ab1047a1CdE0b27F3d2d4D73e1d9050E27dA9D",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "payable",
-                    "inputs": [
-                        {
-                            "name": "_logic",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "admin_",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_data",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AdminChanged",
-                    "inputs": [
-                        {
-                            "name": "previousAdmin",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": false
-                        },
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "BeaconUpgraded",
-                    "inputs": [
-                        {
-                            "name": "beacon",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Upgraded",
-                    "inputs": [
-                        {
-                            "name": "implementation",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "fallback",
-                    "stateMutability": "payable"
-                },
-                {
-                    "type": "receive",
-                    "stateMutability": "payable"
-                }
-            ],
-            "tx_hash": "0x95742c4106165b5b5b9ac6f5567ab0fd7dcba765eece403b7a5de5b5681bcfdc",
-            "block_number": "9758709",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "error",
+          "name": "AccessControlEnforcedDefaultAdminRules",
+          "inputs": []
         },
-        "TACoApplication": {
-            "address": "0x40ab1047a1CdE0b27F3d2d4D73e1d9050E27dA9D",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_token",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        },
-                        {
-                            "name": "_tStaking",
-                            "type": "address",
-                            "internalType": "contract IStaking"
-                        },
-                        {
-                            "name": "_minimumAuthorization",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_minOperatorSeconds",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "_rewardDuration",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "_deauthorizationDuration",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "_commitmentDurationOptions",
-                            "type": "uint64[]",
-                            "internalType": "uint64[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationDecreaseApproved",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        },
-                        {
-                            "name": "toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationDecreaseRequested",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        },
-                        {
-                            "name": "toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationIncreased",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        },
-                        {
-                            "name": "toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationInvoluntaryDecreased",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        },
-                        {
-                            "name": "toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationReSynchronized",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        },
-                        {
-                            "name": "toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "CommitmentMade",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "endCommitment",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Initialized",
-                    "inputs": [
-                        {
-                            "name": "version",
-                            "type": "uint8",
-                            "internalType": "uint8",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorBonded",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "previousOperator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "startTimestamp",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RewardAdded",
-                    "inputs": [
-                        {
-                            "name": "reward",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RewardDistributorSet",
-                    "inputs": [
-                        {
-                            "name": "distributor",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RewardPaid",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "beneficiary",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "reward",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RewardsWithdrawn",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Slashed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "penalty",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        },
-                        {
-                            "name": "investigator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "reward",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "adjudicator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "authorizationDecreaseRequested",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "authorizationIncreased",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedOverall",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedStake",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "availableRewards",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "bondOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "childApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "commitmentDurationOption1",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "commitmentDurationOption2",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "commitmentDurationOption3",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "commitmentDurationOption4",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "deauthorizationDuration",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "finishAuthorizationDecrease",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "getActiveStakingProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_startIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "_maxStakingProviders",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "allAuthorizedTokens",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "activeStakingProviders",
-                            "type": "uint256[2][]",
-                            "internalType": "uint256[2][]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getBeneficiary",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "beneficiary",
-                            "type": "address",
-                            "internalType": "address payable"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getOperatorFromStakingProvider",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getStakingProvidersLength",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initialize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "involuntaryAuthorizationDecrease",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_fromAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_toAmount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "isAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isOperatorConfirmed",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "lastTimeRewardApplicable",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "lastUpdateTime",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "makeCommitment",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_commitmentDuration",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "minOperatorSeconds",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "minimumAuthorization",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "periodFinish",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pushReward",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_reward",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "resynchronizeAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rewardDistributor",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rewardDuration",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rewardPerToken",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rewardPerTokenStored",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rewardRateDecimals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "setAdjudicator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_adjudicator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setChildApplication",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_childApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setRewardDistributor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_rewardDistributor",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "slash",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_penalty",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "_investigator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderFromOperator",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderInfo",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operatorConfirmed",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "operatorStartTimestamp",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        },
-                        {
-                            "name": "authorized",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "deauthorizing",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "endDeauthorization",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        },
-                        {
-                            "name": "tReward",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "rewardPerTokenPaid",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "endCommitment",
-                            "type": "uint64",
-                            "internalType": "uint64"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "tStaking",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IStaking"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "token",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "withdrawRewards",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x95742c4106165b5b5b9ac6f5567ab0fd7dcba765eece403b7a5de5b5681bcfdc",
-            "block_number": "9758709",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        {
+          "type": "error",
+          "name": "AccessControlInvalidDefaultAdmin",
+          "inputs": [
+            {
+              "name": "defaultAdmin",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
         },
-        "MockPolygonRoot": {
-            "address": "0x49e3973596522DD789d8D8dc9DA62e8580701e37",
-            "abi": [
+        {
+          "type": "error",
+          "name": "AccessControlUnauthorizedAccount",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "neededRole",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "AddressEmptyCode",
+          "inputs": [
+            {
+              "name": "target",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "AddressInsufficientBalance",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "FailedInnerCall",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidInitialization",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotInitializing",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "SafeCastOverflowedUintDowncast",
+          "inputs": [
+            {
+              "name": "bits",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "SafeERC20FailedOperation",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "AggregationPosted",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "node",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "aggregatedTranscriptDigest",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DefaultAdminDelayChangeCanceled",
+          "inputs": [],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DefaultAdminDelayChangeScheduled",
+          "inputs": [
+            {
+              "name": "newDelay",
+              "type": "uint48",
+              "internalType": "uint48",
+              "indexed": false
+            },
+            {
+              "name": "effectSchedule",
+              "type": "uint48",
+              "internalType": "uint48",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DefaultAdminTransferCanceled",
+          "inputs": [],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DefaultAdminTransferScheduled",
+          "inputs": [
+            {
+              "name": "newAdmin",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "acceptSchedule",
+              "type": "uint48",
+              "internalType": "uint48",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "EndRitual",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "successful",
+              "type": "bool",
+              "internalType": "bool",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Initialized",
+          "inputs": [
+            {
+              "name": "version",
+              "type": "uint64",
+              "internalType": "uint64",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "MaxDkgSizeChanged",
+          "inputs": [
+            {
+              "name": "oldSize",
+              "type": "uint16",
+              "internalType": "uint16",
+              "indexed": false
+            },
+            {
+              "name": "newSize",
+              "type": "uint16",
+              "internalType": "uint16",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ParticipantPublicKeySet",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "participant",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "publicKey",
+              "type": "tuple",
+              "components": [
                 {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_rootApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
                 },
                 {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
+                  "name": "word1",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
                 },
                 {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rootApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "setRootApplication",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "application",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
+                  "name": "word2",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
                 }
-            ],
-            "tx_hash": "0x6692a573efe0f488e0f797da00ff70e1ec5f1f0fcefd1b87ccf72d5732fc2262",
-            "block_number": "9763517",
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+              ],
+              "internalType": "struct BLS12381.G2Point",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ReimbursementPoolSet",
+          "inputs": [
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RitualAuthorityTransferred",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "previousAuthority",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "newAuthority",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RoleAdminChanged",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": true
+            },
+            {
+              "name": "previousAdminRole",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": true
+            },
+            {
+              "name": "newAdminRole",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RoleGranted",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": true
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "sender",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RoleRevoked",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": true
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "sender",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "StartAggregationRound",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "StartRitual",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "authority",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "participants",
+              "type": "address[]",
+              "internalType": "address[]",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "TimeoutChanged",
+          "inputs": [
+            {
+              "name": "oldTimeout",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": false
+            },
+            {
+              "name": "newTimeout",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "TranscriptPosted",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32",
+              "indexed": true
+            },
+            {
+              "name": "node",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "transcriptDigest",
+              "type": "bytes32",
+              "internalType": "bytes32",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "DEFAULT_ADMIN_ROLE",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "INITIATOR_ROLE",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "TREASURY_ROLE",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "acceptDefaultAdminTransfer",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "application",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITACoChildApplication"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "beginDefaultAdminTransfer",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newAdmin",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "cancelDefaultAdminTransfer",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "changeDefaultAdminDelay",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newDelay",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "cohortFingerprint",
+          "stateMutability": "pure",
+          "inputs": [
+            {
+              "name": "nodes",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "currency",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IERC20"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "defaultAdmin",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "defaultAdminDelay",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "defaultAdminDelayIncreaseWait",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "feeRatePerSecond",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getAuthority",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getParticipantFromProvider",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "provider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "provider",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "aggregated",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "transcript",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "decryptionRequestStaticKey",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ],
+              "internalType": "struct Coordinator.Participant"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getParticipants",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "provider",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "aggregated",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "transcript",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "decryptionRequestStaticKey",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ],
+              "internalType": "struct Coordinator.Participant[]"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getProviderPublicKey",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_provider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_ritualId",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word2",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                }
+              ],
+              "internalType": "struct BLS12381.G2Point"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getPublicKeyFromRitualId",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "dkgPublicKey",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes16",
+                  "internalType": "bytes16"
+                }
+              ],
+              "internalType": "struct BLS12381.G1Point"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getRitualIdFromPublicKey",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "dkgPublicKey",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes16",
+                  "internalType": "bytes16"
+                }
+              ],
+              "internalType": "struct BLS12381.G1Point"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getRitualInitiationCost",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "providers",
+              "type": "address[]",
+              "internalType": "address[]"
+            },
+            {
+              "name": "duration",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getRitualState",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "enum Coordinator.RitualState"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getRoleAdmin",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getThresholdForRitualSize",
+          "stateMutability": "pure",
+          "inputs": [
+            {
+              "name": "size",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "grantRole",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "hasRole",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "initialize",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_timeout",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "_maxDkgSize",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "_admin",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "initiateRitual",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "providers",
+              "type": "address[]",
+              "internalType": "address[]"
+            },
+            {
+              "name": "authority",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "duration",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "accessController",
+              "type": "address",
+              "internalType": "contract IEncryptionAuthorizer"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isEncryptionAuthorized",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "evidence",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "ciphertextHeader",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isInitiationPublic",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isProviderPublicKeySet",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_provider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isRitualActive",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "makeInitiationPublic",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "maxDkgSize",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "numberOfRituals",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "pendingDefaultAdmin",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "newAdmin",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "schedule",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "pendingDefaultAdminDelay",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "newDelay",
+              "type": "uint48",
+              "internalType": "uint48"
+            },
+            {
+              "name": "schedule",
+              "type": "uint48",
+              "internalType": "uint48"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "pendingFees",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "postAggregation",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "aggregatedTranscript",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "dkgPublicKey",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes16",
+                  "internalType": "bytes16"
+                }
+              ],
+              "internalType": "struct BLS12381.G1Point"
+            },
+            {
+              "name": "decryptionRequestStaticKey",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "postTranscript",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "transcript",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "processPendingFee",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "refundableFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "renounceRole",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "revokeRole",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "role",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "rituals",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "initiator",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "initTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "endTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "totalTranscripts",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "totalAggregations",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "authority",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "dkgSize",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "threshold",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "aggregationMismatch",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "accessController",
+              "type": "address",
+              "internalType": "contract IEncryptionAuthorizer"
+            },
+            {
+              "name": "publicKey",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes16",
+                  "internalType": "bytes16"
+                }
+              ],
+              "internalType": "struct BLS12381.G1Point"
+            },
+            {
+              "name": "aggregatedTranscript",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rollbackDefaultAdminDelay",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setMaxDkgSize",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newSize",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setProviderPublicKey",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_publicKey",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "word0",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word1",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "word2",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                }
+              ],
+              "internalType": "struct BLS12381.G2Point"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setReimbursementPool",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "contract IReimbursementPool"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setTimeout",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newTimeout",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "supportsInterface",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "interfaceId",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "timeout",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "totalPendingFees",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transferRitualAuthority",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "newAuthority",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "withdrawTokens",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": []
         }
+      ],
+      "tx_hash": "0xc2fd6f00ad2881cf3fd6b3440746dda9811c2cde625ef6c6d9acf47886bf5b77",
+      "block_number": 42479020,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "LynxRitualToken": {
+      "address": "0x6DED3A2DCaC9dcB62253F063D765F323D6E4be82",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_totalSupplyOfTokens",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "Approval",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Transfer",
+          "inputs": [
+            {
+              "name": "from",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "allowance",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "approve",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "balanceOf",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "decimals",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "uint8"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "decreaseAllowance",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "subtractedValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "increaseAllowance",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "addedValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "name",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "symbol",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "totalSupply",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transfer",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transferFrom",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "from",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "tx_hash": "0x01457fcb28352bfb2cf6f39871f2de00601122cdf7c7a5a0e98fccea88b16b60",
+      "block_number": "40514238",
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "GlobalAllowList": {
+      "address": "0xA02d71363258bB2468c5482e97580B6072D682fF",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_coordinator",
+              "type": "address",
+              "internalType": "contract Coordinator"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "ECDSAInvalidSignature",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ECDSAInvalidSignatureLength",
+          "inputs": [
+            {
+              "name": "length",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "ECDSAInvalidSignatureS",
+          "inputs": [
+            {
+              "name": "s",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "authorize",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "addresses",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "coordinator",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract Coordinator"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "deauthorize",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "addresses",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "isAddressAuthorized",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "encryptor",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isAuthorized",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "ritualId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "evidence",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "ciphertextHeader",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "tx_hash": "0x7611c330e52936ee7022a2dc972d46335611414a36a3d73048e1b3c826a483f4",
+      "block_number": 42479041,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "TACoChildApplication": {
+      "address": "0x8BFB087C4427387dFA217599EA0b860b3F3C49A3",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_rootApplication",
+              "type": "address",
+              "internalType": "contract ITACoChildToRoot"
+            },
+            {
+              "name": "_minimumAuthorization",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "InvalidInitialization",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotInitializing",
+          "inputs": []
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Initialized",
+          "inputs": [
+            {
+              "name": "version",
+              "type": "uint64",
+              "internalType": "uint64",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorConfirmed",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "authorizedStake",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "confirmOperatorAddress",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "coordinator",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getActiveStakingProviders",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_startIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_maxStakingProviders",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "allAuthorizedTokens",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "activeStakingProviders",
+              "type": "bytes32[]",
+              "internalType": "bytes32[]"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getStakingProvidersLength",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "initialize",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_coordinator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "minimumAuthorization",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rootApplication",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITACoChildToRoot"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviderFromOperator",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviderInfo",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "authorized",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "operatorConfirmed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "index",
+              "type": "uint248",
+              "internalType": "uint248"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviders",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "updateAuthorization",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "updateOperator",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "tx_hash": "0xbc45b42b3aa4b774ee7f67c4a7a3c7fda14fa871d5ee851359c4accb44ac6fb2",
+      "block_number": 42478969,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "SubscriptionManager": {
+      "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
+      "abi": [
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "oldFeeRate",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "newFeeRate",
+              "type": "uint256"
+            }
+          ],
+          "name": "FeeRateUpdated",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes16",
+              "name": "policyId",
+              "type": "bytes16"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "sponsor",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint16",
+              "name": "size",
+              "type": "uint16"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "startTimestamp",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "endTimestamp",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "cost",
+              "type": "uint256"
+            }
+          ],
+          "name": "PolicyCreated",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "previousAdminRole",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "newAdminRole",
+              "type": "bytes32"
+            }
+          ],
+          "name": "RoleAdminChanged",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            }
+          ],
+          "name": "RoleGranted",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            }
+          ],
+          "name": "RoleRevoked",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "DEFAULT_ADMIN_ROLE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "SET_RATE_ROLE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "WITHDRAW_ROLE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes16",
+              "name": "_policyId",
+              "type": "bytes16"
+            },
+            {
+              "internalType": "address",
+              "name": "_policyOwner",
+              "type": "address"
+            },
+            {
+              "internalType": "uint16",
+              "name": "_size",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_startTimestamp",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_endTimestamp",
+              "type": "uint32"
+            }
+          ],
+          "name": "createPolicy",
+          "outputs": [],
+          "stateMutability": "payable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "feeRate",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes16",
+              "name": "_policyID",
+              "type": "bytes16"
+            }
+          ],
+          "name": "getPolicy",
+          "outputs": [
+            {
+              "components": [
+                {
+                  "internalType": "address payable",
+                  "name": "sponsor",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "startTimestamp",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "endTimestamp",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "size",
+                  "type": "uint16"
+                },
+                {
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                }
+              ],
+              "internalType": "struct SubscriptionManager.Policy",
+              "name": "",
+              "type": "tuple"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint16",
+              "name": "_size",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_startTimestamp",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_endTimestamp",
+              "type": "uint32"
+            }
+          ],
+          "name": "getPolicyCost",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            }
+          ],
+          "name": "getRoleAdmin",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "grantRole",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "hasRole",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_feeRate",
+              "type": "uint256"
+            }
+          ],
+          "name": "initialize",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes16",
+              "name": "_policyID",
+              "type": "bytes16"
+            }
+          ],
+          "name": "isPolicyActive",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "renounceRole",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "revokeRole",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_ratePerSecond",
+              "type": "uint256"
+            }
+          ],
+          "name": "setFeeRate",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes4",
+              "name": "interfaceId",
+              "type": "bytes4"
+            }
+          ],
+          "name": "supportsInterface",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address payable",
+              "name": "recipient",
+              "type": "address"
+            }
+          ],
+          "name": "sweep",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ],
+      "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
+      "block_number": "25203956",
+      "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
+    },
+    "OpenAccessAuthorizer": {
+      "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
+      "abi": [
+        {
+          "type": "function",
+          "name": "isAuthorized",
+          "stateMutability": "pure",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
+      "block_number": 41671721,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
     }
+  },
+  "5": {
+    "LynxStakingToken": {
+      "address": "0x90990F1F7C952D4D02759802565d62479e8aA936",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_totalSupplyOfTokens",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "Approval",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Transfer",
+          "inputs": [
+            {
+              "name": "from",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "allowance",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "approve",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "balanceOf",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "decimals",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "uint8"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "decreaseAllowance",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "subtractedValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "increaseAllowance",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "addedValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "name",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "symbol",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "totalSupply",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transfer",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transferFrom",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "from",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "tx_hash": "0x727721ea135cd46bc4510b163b524672cf5eed2df1bcdef8886b775d883a34a3",
+      "block_number": "9758692",
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "MockPolygonRoot": {
+      "address": "0x7761756c57398e478F855Fbe31dc500C030F85BE",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_rootApplication",
+              "type": "address",
+              "internalType": "contract ITACoChildToRoot"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "OwnableInvalidOwner",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "OwnableUnauthorizedAccount",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorConfirmed",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorUpdated",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "confirmOperatorAddress",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "rootApplication",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITACoChildToRoot"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "setRootApplication",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "application",
+              "type": "address",
+              "internalType": "contract ITACoChildToRoot"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "updateAuthorization",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "updateOperator",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "tx_hash": "0x4b17504b2177768291c281118aa596245a20969550c646bfedf59ff6dfa88c1e",
+      "block_number": 10054994,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "TACoApplication": {
+      "address": "0x31F0a0B94C829Ba6d902c98CAF8d8462C6c63241",
+      "abi": [
+        {
+          "type": "constructor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "_tStaking",
+              "type": "address",
+              "internalType": "contract IStaking"
+            },
+            {
+              "name": "_minimumAuthorization",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_minOperatorSeconds",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_rewardDuration",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_deauthorizationDuration",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_commitmentDurationOptions",
+              "type": "uint64[]",
+              "internalType": "uint64[]"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "AddressEmptyCode",
+          "inputs": [
+            {
+              "name": "target",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "AddressInsufficientBalance",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "FailedInnerCall",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidInitialization",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotInitializing",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "OwnableInvalidOwner",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "OwnableUnauthorizedAccount",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "SafeCastOverflowedUintDowncast",
+          "inputs": [
+            {
+              "name": "bits",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "SafeERC20FailedOperation",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationDecreaseApproved",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            },
+            {
+              "name": "toAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationDecreaseRequested",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            },
+            {
+              "name": "toAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationIncreased",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            },
+            {
+              "name": "toAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationInvoluntaryDecreased",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            },
+            {
+              "name": "toAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "AuthorizationReSynchronized",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            },
+            {
+              "name": "toAmount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "CommitmentMade",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "endCommitment",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Initialized",
+          "inputs": [
+            {
+              "name": "version",
+              "type": "uint64",
+              "internalType": "uint64",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorBonded",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "previousOperator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "startTimestamp",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OperatorConfirmed",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RewardAdded",
+          "inputs": [
+            {
+              "name": "reward",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RewardDistributorSet",
+          "inputs": [
+            {
+              "name": "distributor",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RewardPaid",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "beneficiary",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "reward",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RewardsWithdrawn",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "amount",
+              "type": "uint96",
+              "internalType": "uint96",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Slashed",
+          "inputs": [
+            {
+              "name": "stakingProvider",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "penalty",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            },
+            {
+              "name": "investigator",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "reward",
+              "type": "uint256",
+              "internalType": "uint256",
+              "indexed": false
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "REWARD_PER_TOKEN_MULTIPLIER",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "adjudicator",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "authorizationDecreaseRequested",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_fromAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_toAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "authorizationIncreased",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_fromAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_toAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "authorizationParameters",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "_minimumAuthorization",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "authorizationDecreaseDelay",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "authorizationDecreaseChangePeriod",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "authorizedOverall",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "authorizedStake",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "availableRewards",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "bondOperator",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "childApplication",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITACoRootToChild"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "commitmentDurationOption1",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "commitmentDurationOption2",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "commitmentDurationOption3",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "commitmentDurationOption4",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "confirmOperatorAddress",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "deauthorizationDuration",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "finishAuthorizationDecrease",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "getActiveStakingProviders",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_startIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_maxStakingProviders",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "allAuthorizedTokens",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "activeStakingProviders",
+              "type": "bytes32[]",
+              "internalType": "bytes32[]"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getBeneficiary",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "beneficiary",
+              "type": "address",
+              "internalType": "address payable"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getOperatorFromStakingProvider",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "getStakingProvidersLength",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "initialize",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "involuntaryAuthorizationDecrease",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_fromAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_toAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "isAuthorized",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "isOperatorConfirmed",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "lastTimeRewardApplicable",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "lastUpdateTime",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "makeCommitment",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_commitmentDuration",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "minOperatorSeconds",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "minimumAuthorization",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "pendingAuthorizationDecrease",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "periodFinish",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "pushReward",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_reward",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "remainingAuthorizationDecreaseDelay",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "resynchronizeAuthorization",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "rewardDistributor",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rewardDuration",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rewardPerToken",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint160",
+              "internalType": "uint160"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rewardPerTokenStored",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint160",
+              "internalType": "uint160"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "rewardRateDecimals",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "setAdjudicator",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_adjudicator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setChildApplication",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_childApplication",
+              "type": "address",
+              "internalType": "contract ITACoRootToChild"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setRewardDistributor",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_rewardDistributor",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "slash",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_penalty",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_investigator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "stakingProviderFromOperator",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_operator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviderInfo",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "operator",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "operatorConfirmed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "operatorStartTimestamp",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "authorized",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "deauthorizing",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "endDeauthorization",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tReward",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "rewardPerTokenPaid",
+              "type": "uint160",
+              "internalType": "uint160"
+            },
+            {
+              "name": "endCommitment",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviders",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "tStaking",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IStaking"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "token",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IERC20"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "withdrawRewards",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "tx_hash": "0x146cf5298f981d9cf7480ee478da5069fca17f18658c7abdda2fc6abf3d2d869",
+      "block_number": 10054982,
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    },
+    "TestnetThresholdStaking": {
+      "address": "0xcdD63981c8f4a2A684d102f7d7693A1c326CDd33",
+      "abi": [
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address",
+              "indexed": true
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "application",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IApplication"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "authorizationIncreased",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_fromAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_toAmount",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "authorizedStake",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "stateMutability": "view",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "rolesOf",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "beneficiary",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "authorizer",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "setApplication",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_application",
+              "type": "address",
+              "internalType": "contract IApplication"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setRoles",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setRoles",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_beneficiary",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_authorizer",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "setStakes",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_tStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_keepInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "_nuInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ],
+          "outputs": []
+        },
+        {
+          "type": "function",
+          "name": "stakedNu",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakes",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "_stakingProvider",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "tStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "keepInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "nuInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "stakingProviderInfo",
+          "stateMutability": "view",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "beneficiary",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "authorizer",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "keepInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "nuInTStake",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": []
+        }
+      ],
+      "tx_hash": "0x1d2bd03c0a9204b8ec1aae6f10eed732699d91da7fe66e20adf154259fdff027",
+      "block_number": "9758696",
+      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+    }
+  }
 }

--- a/deployment/artifacts/lynx.json
+++ b/deployment/artifacts/lynx.json
@@ -1,5259 +1,5259 @@
 {
-  "80001": {
-    "MockPolygonChild": {
-      "address": "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
-      "abi": [
-        {
-          "type": "event",
-          "name": "AuthorizationUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
+    "80001": {
+        "OpenAccessAuthorizer": {
+            "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
+            "abi": [
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
+            "block_number": 41671721,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "event",
-          "name": "OperatorConfirmed",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
+        "Coordinator": {
+            "address": "0x530608219a8A671FD183534b17E2a2CE09e782a4",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_application",
+                            "type": "address",
+                            "internalType": "contract ITACoChildApplication"
+                        },
+                        {
+                            "name": "_currency",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "_feeRatePerSecond",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlBadConfirmation",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlEnforcedDefaultAdminDelay",
+                    "inputs": [
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlEnforcedDefaultAdminRules",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlInvalidDefaultAdmin",
+                    "inputs": [
+                        {
+                            "name": "defaultAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "neededRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressEmptyCode",
+                    "inputs": [
+                        {
+                            "name": "target",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressInsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "FailedInnerCall",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "SafeCastOverflowedUintDowncast",
+                    "inputs": [
+                        {
+                            "name": "bits",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeERC20FailedOperation",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AggregationPosted",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "node",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "aggregatedTranscriptDigest",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminDelayChangeCanceled",
+                    "inputs": [],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminDelayChangeScheduled",
+                    "inputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        },
+                        {
+                            "name": "effectSchedule",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminTransferCanceled",
+                    "inputs": [],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminTransferScheduled",
+                    "inputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "acceptSchedule",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "EndRitual",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "successful",
+                            "type": "bool",
+                            "internalType": "bool",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "MaxDkgSizeChanged",
+                    "inputs": [
+                        {
+                            "name": "oldSize",
+                            "type": "uint16",
+                            "internalType": "uint16",
+                            "indexed": false
+                        },
+                        {
+                            "name": "newSize",
+                            "type": "uint16",
+                            "internalType": "uint16",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ParticipantPublicKeySet",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "participant",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ReimbursementPoolSet",
+                    "inputs": [
+                        {
+                            "name": "pool",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RitualAuthorityTransferred",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAuthority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAuthority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleAdminChanged",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleGranted",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleRevoked",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "StartAggregationRound",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "StartRitual",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "participants",
+                            "type": "address[]",
+                            "internalType": "address[]",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "TimeoutChanged",
+                    "inputs": [
+                        {
+                            "name": "oldTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        },
+                        {
+                            "name": "newTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "TranscriptPosted",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "node",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "transcriptDigest",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "DEFAULT_ADMIN_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "INITIATOR_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "TREASURY_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "acceptDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "application",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildApplication"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "beginDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "cancelDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "changeDefaultAdminDelay",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "cohortFingerprint",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "nodes",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "currency",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdmin",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdminDelay",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdminDelayIncreaseWait",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "feeRatePerSecond",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getAuthority",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipantFromProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipants",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple[]",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getProviderPublicKey",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_provider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_ritualId",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getPublicKeyFromRitualId",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "dkgPublicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualIdFromPublicKey",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "dkgPublicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualInitiationCost",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualState",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint8",
+                            "internalType": "enum Coordinator.RitualState"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRoleAdmin",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getThresholdForRitualSize",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "grantRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "hasRole",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_timeout",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_maxDkgSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_admin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "initiateRitual",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isEncryptionAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "evidence",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "ciphertextHeader",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isInitiationPublic",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isProviderPublicKeySet",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_provider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isRitualActive",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "makeInitiationPublic",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "maxDkgSize",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "numberOfRituals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingDefaultAdmin",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingDefaultAdminDelay",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        },
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingFees",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "postAggregation",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "aggregatedTranscript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "dkgPublicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        },
+                        {
+                            "name": "decryptionRequestStaticKey",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "postTranscript",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "transcript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "processPendingFee",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "refundableFee",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "revokeRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rituals",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "initiator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "initTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "totalTranscripts",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "totalAggregations",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "dkgSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "threshold",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "aggregationMismatch",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        },
+                        {
+                            "name": "publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        },
+                        {
+                            "name": "aggregatedTranscript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rollbackDefaultAdminDelay",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setMaxDkgSize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setProviderPublicKey",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setReimbursementPool",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "pool",
+                            "type": "address",
+                            "internalType": "contract IReimbursementPool"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setTimeout",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "supportsInterface",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "interfaceId",
+                            "type": "bytes4",
+                            "internalType": "bytes4"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "timeout",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "totalPendingFees",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferRitualAuthority",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "newAuthority",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "withdrawTokens",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0xc2fd6f00ad2881cf3fd6b3440746dda9811c2cde625ef6c6d9acf47886bf5b77",
+            "block_number": 42479020,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "event",
-          "name": "OperatorUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
+        "TACoChildApplication": {
+            "address": "0x8BFB087C4427387dFA217599EA0b860b3F3C49A3",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rootApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        },
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getStakingProvidersLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "minimumAuthorization",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rootApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderFromOperator",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "operatorConfirmed",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "index",
+                            "type": "uint248",
+                            "internalType": "uint248"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0xbc45b42b3aa4b774ee7f67c4a7a3c7fda14fa871d5ee851359c4accb44ac6fb2",
+            "block_number": 42478969,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "event",
-          "name": "OwnershipTransferred",
-          "inputs": [
-            {
-              "name": "previousOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
+        "SubscriptionManager": {
+            "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
+            "abi": [
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": false,
+                            "internalType": "uint256",
+                            "name": "oldFeeRate",
+                            "type": "uint256"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint256",
+                            "name": "newFeeRate",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "FeeRateUpdated",
+                    "type": "event"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "internalType": "bytes16",
+                            "name": "policyId",
+                            "type": "bytes16"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "sponsor",
+                            "type": "address"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "owner",
+                            "type": "address"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint16",
+                            "name": "size",
+                            "type": "uint16"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint32",
+                            "name": "startTimestamp",
+                            "type": "uint32"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint32",
+                            "name": "endTimestamp",
+                            "type": "uint32"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint256",
+                            "name": "cost",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "PolicyCreated",
+                    "type": "event"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "previousAdminRole",
+                            "type": "bytes32"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "newAdminRole",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "name": "RoleAdminChanged",
+                    "type": "event"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "sender",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "RoleGranted",
+                    "type": "event"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "address",
+                            "name": "sender",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "RoleRevoked",
+                    "type": "event"
+                },
+                {
+                    "inputs": [],
+                    "name": "DEFAULT_ADMIN_ROLE",
+                    "outputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [],
+                    "name": "SET_RATE_ROLE",
+                    "outputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [],
+                    "name": "WITHDRAW_ROLE",
+                    "outputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes16",
+                            "name": "_policyId",
+                            "type": "bytes16"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "_policyOwner",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "_size",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "_startTimestamp",
+                            "type": "uint32"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "_endTimestamp",
+                            "type": "uint32"
+                        }
+                    ],
+                    "name": "createPolicy",
+                    "outputs": [],
+                    "stateMutability": "payable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [],
+                    "name": "feeRate",
+                    "outputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "",
+                            "type": "uint256"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes16",
+                            "name": "_policyID",
+                            "type": "bytes16"
+                        }
+                    ],
+                    "name": "getPolicy",
+                    "outputs": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address payable",
+                                    "name": "sponsor",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "startTimestamp",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "endTimestamp",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "size",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "owner",
+                                    "type": "address"
+                                }
+                            ],
+                            "internalType": "struct SubscriptionManager.Policy",
+                            "name": "",
+                            "type": "tuple"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint16",
+                            "name": "_size",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "_startTimestamp",
+                            "type": "uint32"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "_endTimestamp",
+                            "type": "uint32"
+                        }
+                    ],
+                    "name": "getPolicyCost",
+                    "outputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "",
+                            "type": "uint256"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "name": "getRoleAdmin",
+                    "outputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "grantRole",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "hasRole",
+                    "outputs": [
+                        {
+                            "internalType": "bool",
+                            "name": "",
+                            "type": "bool"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "_feeRate",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "initialize",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes16",
+                            "name": "_policyID",
+                            "type": "bytes16"
+                        }
+                    ],
+                    "name": "isPolicyActive",
+                    "outputs": [
+                        {
+                            "internalType": "bool",
+                            "name": "",
+                            "type": "bool"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "renounceRole",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "role",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "revokeRole",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "_ratePerSecond",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "setFeeRate",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes4",
+                            "name": "interfaceId",
+                            "type": "bytes4"
+                        }
+                    ],
+                    "name": "supportsInterface",
+                    "outputs": [
+                        {
+                            "internalType": "bool",
+                            "name": "",
+                            "type": "bool"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "sweep",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                }
+            ],
+            "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
+            "block_number": "25203956",
+            "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
         },
-        {
-          "type": "function",
-          "name": "childApplication",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract ITACoRootToChild"
-            }
-          ]
+        "MockPolygonChild": {
+            "address": "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
+            "abi": [
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "childApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setChildApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_childApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x05c20dd9661b89048e50304d6b4cf626167c44bb64b0137aeb88155d277b9c94",
+            "block_number": "40514106",
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "function",
-          "name": "confirmOperatorAddress",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
+        "GlobalAllowList": {
+            "address": "0xA02d71363258bB2468c5482e97580B6072D682fF",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignature",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignatureLength",
+                    "inputs": [
+                        {
+                            "name": "length",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignatureS",
+                    "inputs": [
+                        {
+                            "name": "s",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "addresses",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "deauthorize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "addresses",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "isAddressAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "encryptor",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "evidence",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "ciphertextHeader",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0x7611c330e52936ee7022a2dc972d46335611414a36a3d73048e1b3c826a483f4",
+            "block_number": 42479041,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "function",
-          "name": "owner",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "renounceOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setChildApplication",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_childApplication",
-              "type": "address",
-              "internalType": "contract ITACoRootToChild"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "transferOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "updateAuthorization",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_amount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "updateOperator",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
+        "LynxRitualToken": {
+            "address": "0x6DED3A2DCaC9dcB62253F063D765F323D6E4be82",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_totalSupplyOfTokens",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "Approval",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Transfer",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "allowance",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "approve",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "balanceOf",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "decimals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "decreaseAllowance",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "subtractedValue",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "increaseAllowance",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "addedValue",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "name",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "symbol",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "totalSupply",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferFrom",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0x01457fcb28352bfb2cf6f39871f2de00601122cdf7c7a5a0e98fccea88b16b60",
+            "block_number": "40514238",
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         }
-      ],
-      "tx_hash": "0x05c20dd9661b89048e50304d6b4cf626167c44bb64b0137aeb88155d277b9c94",
-      "block_number": "40514106",
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
     },
-    "Coordinator": {
-      "address": "0x530608219a8A671FD183534b17E2a2CE09e782a4",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_application",
-              "type": "address",
-              "internalType": "contract ITACoChildApplication"
-            },
-            {
-              "name": "_currency",
-              "type": "address",
-              "internalType": "contract IERC20"
-            },
-            {
-              "name": "_feeRatePerSecond",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AccessControlBadConfirmation",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "AccessControlEnforcedDefaultAdminDelay",
-          "inputs": [
-            {
-              "name": "schedule",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AccessControlEnforcedDefaultAdminRules",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "AccessControlInvalidDefaultAdmin",
-          "inputs": [
-            {
-              "name": "defaultAdmin",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AccessControlUnauthorizedAccount",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "neededRole",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AddressEmptyCode",
-          "inputs": [
-            {
-              "name": "target",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AddressInsufficientBalance",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "FailedInnerCall",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "InvalidInitialization",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "NotInitializing",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "SafeCastOverflowedUintDowncast",
-          "inputs": [
-            {
-              "name": "bits",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "SafeERC20FailedOperation",
-          "inputs": [
-            {
-              "name": "token",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "AggregationPosted",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "node",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "aggregatedTranscriptDigest",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "DefaultAdminDelayChangeCanceled",
-          "inputs": [],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "DefaultAdminDelayChangeScheduled",
-          "inputs": [
-            {
-              "name": "newDelay",
-              "type": "uint48",
-              "internalType": "uint48",
-              "indexed": false
-            },
-            {
-              "name": "effectSchedule",
-              "type": "uint48",
-              "internalType": "uint48",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "DefaultAdminTransferCanceled",
-          "inputs": [],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "DefaultAdminTransferScheduled",
-          "inputs": [
-            {
-              "name": "newAdmin",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "acceptSchedule",
-              "type": "uint48",
-              "internalType": "uint48",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "EndRitual",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "successful",
-              "type": "bool",
-              "internalType": "bool",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Initialized",
-          "inputs": [
-            {
-              "name": "version",
-              "type": "uint64",
-              "internalType": "uint64",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "MaxDkgSizeChanged",
-          "inputs": [
-            {
-              "name": "oldSize",
-              "type": "uint16",
-              "internalType": "uint16",
-              "indexed": false
-            },
-            {
-              "name": "newSize",
-              "type": "uint16",
-              "internalType": "uint16",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "ParticipantPublicKeySet",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "participant",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "publicKey",
-              "type": "tuple",
-              "components": [
+    "5": {
+        "LynxStakingToken": {
+            "address": "0x90990F1F7C952D4D02759802565d62479e8aA936",
+            "abi": [
                 {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_totalSupplyOfTokens",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
                 },
                 {
-                  "name": "word1",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "event",
+                    "name": "Approval",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
                 },
                 {
-                  "name": "word2",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "event",
+                    "name": "Transfer",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "allowance",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "approve",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "balanceOf",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "decimals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "decreaseAllowance",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "subtractedValue",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "increaseAllowance",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "addedValue",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "name",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "symbol",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "totalSupply",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferFrom",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
                 }
-              ],
-              "internalType": "struct BLS12381.G2Point",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
+            ],
+            "tx_hash": "0x727721ea135cd46bc4510b163b524672cf5eed2df1bcdef8886b775d883a34a3",
+            "block_number": "9758692",
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "event",
-          "name": "ReimbursementPoolSet",
-          "inputs": [
-            {
-              "name": "pool",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RitualAuthorityTransferred",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "previousAuthority",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "newAuthority",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RoleAdminChanged",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": true
-            },
-            {
-              "name": "previousAdminRole",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": true
-            },
-            {
-              "name": "newAdminRole",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RoleGranted",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": true
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "sender",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RoleRevoked",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": true
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "sender",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "StartAggregationRound",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "StartRitual",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "authority",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "participants",
-              "type": "address[]",
-              "internalType": "address[]",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "TimeoutChanged",
-          "inputs": [
-            {
-              "name": "oldTimeout",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": false
-            },
-            {
-              "name": "newTimeout",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "TranscriptPosted",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32",
-              "indexed": true
-            },
-            {
-              "name": "node",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "transcriptDigest",
-              "type": "bytes32",
-              "internalType": "bytes32",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "DEFAULT_ADMIN_ROLE",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "INITIATOR_ROLE",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "TREASURY_ROLE",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "acceptDefaultAdminTransfer",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "application",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract ITACoChildApplication"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "beginDefaultAdminTransfer",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newAdmin",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "cancelDefaultAdminTransfer",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "changeDefaultAdminDelay",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newDelay",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "cohortFingerprint",
-          "stateMutability": "pure",
-          "inputs": [
-            {
-              "name": "nodes",
-              "type": "address[]",
-              "internalType": "address[]"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "currency",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract IERC20"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "defaultAdmin",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "defaultAdminDelay",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "defaultAdminDelayIncreaseWait",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "feeRatePerSecond",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getAuthority",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getParticipantFromProvider",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "provider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "tuple",
-              "components": [
+        "TestnetThresholdStaking": {
+            "address": "0xcdD63981c8f4a2A684d102f7d7693A1c326CDd33",
+            "abi": [
                 {
-                  "name": "provider",
-                  "type": "address",
-                  "internalType": "address"
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
                 },
                 {
-                  "name": "aggregated",
-                  "type": "bool",
-                  "internalType": "bool"
+                    "type": "function",
+                    "name": "application",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IApplication"
+                        }
+                    ]
                 },
                 {
-                  "name": "transcript",
-                  "type": "bytes",
-                  "internalType": "bytes"
+                    "type": "function",
+                    "name": "authorizationIncreased",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
                 },
                 {
-                  "name": "decryptionRequestStaticKey",
-                  "type": "bytes",
-                  "internalType": "bytes"
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rolesOf",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address payable"
+                        },
+                        {
+                            "name": "authorizer",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "setApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_application",
+                            "type": "address",
+                            "internalType": "contract IApplication"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setRoles",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setRoles",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_beneficiary",
+                            "type": "address",
+                            "internalType": "address payable"
+                        },
+                        {
+                            "name": "_authorizer",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setStakes",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_tStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_keepInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_nuInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "stakedNu",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakes",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "tStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "keepInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "nuInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address payable"
+                        },
+                        {
+                            "name": "authorizer",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "tStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "keepInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "nuInTStake",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
                 }
-              ],
-              "internalType": "struct Coordinator.Participant"
-            }
-          ]
+            ],
+            "tx_hash": "0x1d2bd03c0a9204b8ec1aae6f10eed732699d91da7fe66e20adf154259fdff027",
+            "block_number": "9758696",
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "function",
-          "name": "getParticipants",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "tuple[]",
-              "components": [
+        "TACoApplication": {
+            "address": "0x31F0a0B94C829Ba6d902c98CAF8d8462C6c63241",
+            "abi": [
                 {
-                  "name": "provider",
-                  "type": "address",
-                  "internalType": "address"
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_token",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "_tStaking",
+                            "type": "address",
+                            "internalType": "contract IStaking"
+                        },
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_minOperatorSeconds",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_rewardDuration",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_deauthorizationDuration",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_commitmentDurationOptions",
+                            "type": "uint64[]",
+                            "internalType": "uint64[]"
+                        }
+                    ]
                 },
                 {
-                  "name": "aggregated",
-                  "type": "bool",
-                  "internalType": "bool"
+                    "type": "error",
+                    "name": "AddressEmptyCode",
+                    "inputs": [
+                        {
+                            "name": "target",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
                 },
                 {
-                  "name": "transcript",
-                  "type": "bytes",
-                  "internalType": "bytes"
+                    "type": "error",
+                    "name": "AddressInsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
                 },
                 {
-                  "name": "decryptionRequestStaticKey",
-                  "type": "bytes",
-                  "internalType": "bytes"
+                    "type": "error",
+                    "name": "FailedInnerCall",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableInvalidOwner",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeCastOverflowedUintDowncast",
+                    "inputs": [
+                        {
+                            "name": "bits",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeERC20FailedOperation",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationDecreaseApproved",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationDecreaseRequested",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationIncreased",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationInvoluntaryDecreased",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationReSynchronized",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "CommitmentMade",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "endCommitment",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorBonded",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousOperator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "startTimestamp",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardAdded",
+                    "inputs": [
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardDistributorSet",
+                    "inputs": [
+                        {
+                            "name": "distributor",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardPaid",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardsWithdrawn",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Slashed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "penalty",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        },
+                        {
+                            "name": "investigator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "REWARD_PER_TOKEN_MULTIPLIER",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "adjudicator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationDecreaseRequested",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationIncreased",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationParameters",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "authorizationDecreaseDelay",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "authorizationDecreaseChangePeriod",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedOverall",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "availableRewards",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "bondOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "childApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption1",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption2",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption3",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption4",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "deauthorizationDuration",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "finishAuthorizationDecrease",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getBeneficiary",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address payable"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getOperatorFromStakingProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getStakingProvidersLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "involuntaryAuthorizationDecrease",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isOperatorConfirmed",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "lastTimeRewardApplicable",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "lastUpdateTime",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "makeCommitment",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_commitmentDuration",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "minOperatorSeconds",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "minimumAuthorization",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingAuthorizationDecrease",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "periodFinish",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pushReward",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_reward",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "remainingAuthorizationDecreaseDelay",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "resynchronizeAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rewardDistributor",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardDuration",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardPerToken",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardPerTokenStored",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardRateDecimals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "setAdjudicator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_adjudicator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setChildApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_childApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setRewardDistributor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rewardDistributor",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "slash",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_penalty",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_investigator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderFromOperator",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operatorConfirmed",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "operatorStartTimestamp",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "tReward",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "rewardPerTokenPaid",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        },
+                        {
+                            "name": "endCommitment",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "tStaking",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IStaking"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "token",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "withdrawRewards",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
                 }
-              ],
-              "internalType": "struct Coordinator.Participant[]"
-            }
-          ]
+            ],
+            "tx_hash": "0x146cf5298f981d9cf7480ee478da5069fca17f18658c7abdda2fc6abf3d2d869",
+            "block_number": 10054982,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
-        {
-          "type": "function",
-          "name": "getProviderPublicKey",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_provider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_ritualId",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "tuple",
-              "components": [
+        "MockPolygonRoot": {
+            "address": "0x7761756c57398e478F855Fbe31dc500C030F85BE",
+            "abi": [
                 {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rootApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ]
                 },
                 {
-                  "name": "word1",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "error",
+                    "name": "OwnableInvalidOwner",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
                 },
                 {
-                  "name": "word2",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
+                    "type": "error",
+                    "name": "OwnableUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rootApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "setRootApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "application",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
                 }
-              ],
-              "internalType": "struct BLS12381.G2Point"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getPublicKeyFromRitualId",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "dkgPublicKey",
-              "type": "tuple",
-              "components": [
-                {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word1",
-                  "type": "bytes16",
-                  "internalType": "bytes16"
-                }
-              ],
-              "internalType": "struct BLS12381.G1Point"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getRitualIdFromPublicKey",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "dkgPublicKey",
-              "type": "tuple",
-              "components": [
-                {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word1",
-                  "type": "bytes16",
-                  "internalType": "bytes16"
-                }
-              ],
-              "internalType": "struct BLS12381.G1Point"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getRitualInitiationCost",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "providers",
-              "type": "address[]",
-              "internalType": "address[]"
-            },
-            {
-              "name": "duration",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getRitualState",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint8",
-              "internalType": "enum Coordinator.RitualState"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getRoleAdmin",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getThresholdForRitualSize",
-          "stateMutability": "pure",
-          "inputs": [
-            {
-              "name": "size",
-              "type": "uint16",
-              "internalType": "uint16"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint16",
-              "internalType": "uint16"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "grantRole",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "hasRole",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "initialize",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_timeout",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "_maxDkgSize",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "_admin",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "initiateRitual",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "providers",
-              "type": "address[]",
-              "internalType": "address[]"
-            },
-            {
-              "name": "authority",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "duration",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "accessController",
-              "type": "address",
-              "internalType": "contract IEncryptionAuthorizer"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isEncryptionAuthorized",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "evidence",
-              "type": "bytes",
-              "internalType": "bytes"
-            },
-            {
-              "name": "ciphertextHeader",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isInitiationPublic",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isProviderPublicKeySet",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_provider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isRitualActive",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "makeInitiationPublic",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "maxDkgSize",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint16",
-              "internalType": "uint16"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "numberOfRituals",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "owner",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "pendingDefaultAdmin",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "newAdmin",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "schedule",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "pendingDefaultAdminDelay",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "newDelay",
-              "type": "uint48",
-              "internalType": "uint48"
-            },
-            {
-              "name": "schedule",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "pendingFees",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "postAggregation",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "aggregatedTranscript",
-              "type": "bytes",
-              "internalType": "bytes"
-            },
-            {
-              "name": "dkgPublicKey",
-              "type": "tuple",
-              "components": [
-                {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word1",
-                  "type": "bytes16",
-                  "internalType": "bytes16"
-                }
-              ],
-              "internalType": "struct BLS12381.G1Point"
-            },
-            {
-              "name": "decryptionRequestStaticKey",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "postTranscript",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "transcript",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "processPendingFee",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "refundableFee",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "renounceRole",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "revokeRole",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "role",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "rituals",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "initiator",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "initTimestamp",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "endTimestamp",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "totalTranscripts",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "totalAggregations",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "authority",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "dkgSize",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "threshold",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "aggregationMismatch",
-              "type": "bool",
-              "internalType": "bool"
-            },
-            {
-              "name": "accessController",
-              "type": "address",
-              "internalType": "contract IEncryptionAuthorizer"
-            },
-            {
-              "name": "publicKey",
-              "type": "tuple",
-              "components": [
-                {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word1",
-                  "type": "bytes16",
-                  "internalType": "bytes16"
-                }
-              ],
-              "internalType": "struct BLS12381.G1Point"
-            },
-            {
-              "name": "aggregatedTranscript",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rollbackDefaultAdminDelay",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setMaxDkgSize",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newSize",
-              "type": "uint16",
-              "internalType": "uint16"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setProviderPublicKey",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_publicKey",
-              "type": "tuple",
-              "components": [
-                {
-                  "name": "word0",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word1",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "word2",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                }
-              ],
-              "internalType": "struct BLS12381.G2Point"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setReimbursementPool",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "pool",
-              "type": "address",
-              "internalType": "contract IReimbursementPool"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setTimeout",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newTimeout",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "supportsInterface",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "interfaceId",
-              "type": "bytes4",
-              "internalType": "bytes4"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "timeout",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint32",
-              "internalType": "uint32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "totalPendingFees",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transferRitualAuthority",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "newAuthority",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "withdrawTokens",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "token",
-              "type": "address",
-              "internalType": "contract IERC20"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": []
+            ],
+            "tx_hash": "0x4b17504b2177768291c281118aa596245a20969550c646bfedf59ff6dfa88c1e",
+            "block_number": 10054994,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         }
-      ],
-      "tx_hash": "0xc2fd6f00ad2881cf3fd6b3440746dda9811c2cde625ef6c6d9acf47886bf5b77",
-      "block_number": 42479020,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "LynxRitualToken": {
-      "address": "0x6DED3A2DCaC9dcB62253F063D765F323D6E4be82",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_totalSupplyOfTokens",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "Approval",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Transfer",
-          "inputs": [
-            {
-              "name": "from",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "allowance",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "approve",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "balanceOf",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "decimals",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint8",
-              "internalType": "uint8"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "decreaseAllowance",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "subtractedValue",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "increaseAllowance",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "addedValue",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "name",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "string",
-              "internalType": "string"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "symbol",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "string",
-              "internalType": "string"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "totalSupply",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transfer",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transferFrom",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "from",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        }
-      ],
-      "tx_hash": "0x01457fcb28352bfb2cf6f39871f2de00601122cdf7c7a5a0e98fccea88b16b60",
-      "block_number": "40514238",
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "GlobalAllowList": {
-      "address": "0xA02d71363258bB2468c5482e97580B6072D682fF",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_coordinator",
-              "type": "address",
-              "internalType": "contract Coordinator"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "ECDSAInvalidSignature",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "ECDSAInvalidSignatureLength",
-          "inputs": [
-            {
-              "name": "length",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "ECDSAInvalidSignatureS",
-          "inputs": [
-            {
-              "name": "s",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "authorize",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "addresses",
-              "type": "address[]",
-              "internalType": "address[]"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "coordinator",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract Coordinator"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "deauthorize",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "addresses",
-              "type": "address[]",
-              "internalType": "address[]"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "isAddressAuthorized",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "encryptor",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isAuthorized",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "ritualId",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "evidence",
-              "type": "bytes",
-              "internalType": "bytes"
-            },
-            {
-              "name": "ciphertextHeader",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        }
-      ],
-      "tx_hash": "0x7611c330e52936ee7022a2dc972d46335611414a36a3d73048e1b3c826a483f4",
-      "block_number": 42479041,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "TACoChildApplication": {
-      "address": "0x8BFB087C4427387dFA217599EA0b860b3F3C49A3",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_rootApplication",
-              "type": "address",
-              "internalType": "contract ITACoChildToRoot"
-            },
-            {
-              "name": "_minimumAuthorization",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "InvalidInitialization",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "NotInitializing",
-          "inputs": []
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Initialized",
-          "inputs": [
-            {
-              "name": "version",
-              "type": "uint64",
-              "internalType": "uint64",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorConfirmed",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "authorizedStake",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "confirmOperatorAddress",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "coordinator",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getActiveStakingProviders",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_startIndex",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "_maxStakingProviders",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "allAuthorizedTokens",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "activeStakingProviders",
-              "type": "bytes32[]",
-              "internalType": "bytes32[]"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getStakingProvidersLength",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "initialize",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_coordinator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "minimumAuthorization",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rootApplication",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract ITACoChildToRoot"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviderFromOperator",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviderInfo",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "authorized",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "operatorConfirmed",
-              "type": "bool",
-              "internalType": "bool"
-            },
-            {
-              "name": "index",
-              "type": "uint248",
-              "internalType": "uint248"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviders",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "updateAuthorization",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "updateOperator",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        }
-      ],
-      "tx_hash": "0xbc45b42b3aa4b774ee7f67c4a7a3c7fda14fa871d5ee851359c4accb44ac6fb2",
-      "block_number": 42478969,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "SubscriptionManager": {
-      "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
-      "abi": [
-        {
-          "anonymous": false,
-          "inputs": [
-            {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "oldFeeRate",
-              "type": "uint256"
-            },
-            {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "newFeeRate",
-              "type": "uint256"
-            }
-          ],
-          "name": "FeeRateUpdated",
-          "type": "event"
-        },
-        {
-          "anonymous": false,
-          "inputs": [
-            {
-              "indexed": true,
-              "internalType": "bytes16",
-              "name": "policyId",
-              "type": "bytes16"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "sponsor",
-              "type": "address"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
-            },
-            {
-              "indexed": false,
-              "internalType": "uint16",
-              "name": "size",
-              "type": "uint16"
-            },
-            {
-              "indexed": false,
-              "internalType": "uint32",
-              "name": "startTimestamp",
-              "type": "uint32"
-            },
-            {
-              "indexed": false,
-              "internalType": "uint32",
-              "name": "endTimestamp",
-              "type": "uint32"
-            },
-            {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "cost",
-              "type": "uint256"
-            }
-          ],
-          "name": "PolicyCreated",
-          "type": "event"
-        },
-        {
-          "anonymous": false,
-          "inputs": [
-            {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "previousAdminRole",
-              "type": "bytes32"
-            },
-            {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "newAdminRole",
-              "type": "bytes32"
-            }
-          ],
-          "name": "RoleAdminChanged",
-          "type": "event"
-        },
-        {
-          "anonymous": false,
-          "inputs": [
-            {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-            }
-          ],
-          "name": "RoleGranted",
-          "type": "event"
-        },
-        {
-          "anonymous": false,
-          "inputs": [
-            {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            },
-            {
-              "indexed": true,
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-            }
-          ],
-          "name": "RoleRevoked",
-          "type": "event"
-        },
-        {
-          "inputs": [],
-          "name": "DEFAULT_ADMIN_ROLE",
-          "outputs": [
-            {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [],
-          "name": "SET_RATE_ROLE",
-          "outputs": [
-            {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [],
-          "name": "WITHDRAW_ROLE",
-          "outputs": [
-            {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes16",
-              "name": "_policyId",
-              "type": "bytes16"
-            },
-            {
-              "internalType": "address",
-              "name": "_policyOwner",
-              "type": "address"
-            },
-            {
-              "internalType": "uint16",
-              "name": "_size",
-              "type": "uint16"
-            },
-            {
-              "internalType": "uint32",
-              "name": "_startTimestamp",
-              "type": "uint32"
-            },
-            {
-              "internalType": "uint32",
-              "name": "_endTimestamp",
-              "type": "uint32"
-            }
-          ],
-          "name": "createPolicy",
-          "outputs": [],
-          "stateMutability": "payable",
-          "type": "function"
-        },
-        {
-          "inputs": [],
-          "name": "feeRate",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes16",
-              "name": "_policyID",
-              "type": "bytes16"
-            }
-          ],
-          "name": "getPolicy",
-          "outputs": [
-            {
-              "components": [
-                {
-                  "internalType": "address payable",
-                  "name": "sponsor",
-                  "type": "address"
-                },
-                {
-                  "internalType": "uint32",
-                  "name": "startTimestamp",
-                  "type": "uint32"
-                },
-                {
-                  "internalType": "uint32",
-                  "name": "endTimestamp",
-                  "type": "uint32"
-                },
-                {
-                  "internalType": "uint16",
-                  "name": "size",
-                  "type": "uint16"
-                },
-                {
-                  "internalType": "address",
-                  "name": "owner",
-                  "type": "address"
-                }
-              ],
-              "internalType": "struct SubscriptionManager.Policy",
-              "name": "",
-              "type": "tuple"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint16",
-              "name": "_size",
-              "type": "uint16"
-            },
-            {
-              "internalType": "uint32",
-              "name": "_startTimestamp",
-              "type": "uint32"
-            },
-            {
-              "internalType": "uint32",
-              "name": "_endTimestamp",
-              "type": "uint32"
-            }
-          ],
-          "name": "getPolicyCost",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            }
-          ],
-          "name": "getRoleAdmin",
-          "outputs": [
-            {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            }
-          ],
-          "name": "grantRole",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            }
-          ],
-          "name": "hasRole",
-          "outputs": [
-            {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "_feeRate",
-              "type": "uint256"
-            }
-          ],
-          "name": "initialize",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes16",
-              "name": "_policyID",
-              "type": "bytes16"
-            }
-          ],
-          "name": "isPolicyActive",
-          "outputs": [
-            {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            }
-          ],
-          "name": "renounceRole",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-            }
-          ],
-          "name": "revokeRole",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "_ratePerSecond",
-              "type": "uint256"
-            }
-          ],
-          "name": "setFeeRate",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes4",
-              "name": "interfaceId",
-              "type": "bytes4"
-            }
-          ],
-          "name": "supportsInterface",
-          "outputs": [
-            {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address payable",
-              "name": "recipient",
-              "type": "address"
-            }
-          ],
-          "name": "sweep",
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "type": "function"
-        }
-      ],
-      "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
-      "block_number": "25203956",
-      "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
-    },
-    "OpenAccessAuthorizer": {
-      "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
-      "abi": [
-        {
-          "type": "function",
-          "name": "isAuthorized",
-          "stateMutability": "pure",
-          "inputs": [
-            {
-              "name": "",
-              "type": "uint32",
-              "internalType": "uint32"
-            },
-            {
-              "name": "",
-              "type": "bytes",
-              "internalType": "bytes"
-            },
-            {
-              "name": "",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        }
-      ],
-      "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
-      "block_number": 41671721,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
     }
-  },
-  "5": {
-    "LynxStakingToken": {
-      "address": "0x90990F1F7C952D4D02759802565d62479e8aA936",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_totalSupplyOfTokens",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "Approval",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Transfer",
-          "inputs": [
-            {
-              "name": "from",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "allowance",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "approve",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "balanceOf",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "decimals",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint8",
-              "internalType": "uint8"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "decreaseAllowance",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "subtractedValue",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "increaseAllowance",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "spender",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "addedValue",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "name",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "string",
-              "internalType": "string"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "symbol",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "string",
-              "internalType": "string"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "totalSupply",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transfer",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transferFrom",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "from",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "to",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        }
-      ],
-      "tx_hash": "0x727721ea135cd46bc4510b163b524672cf5eed2df1bcdef8886b775d883a34a3",
-      "block_number": "9758692",
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "MockPolygonRoot": {
-      "address": "0x7761756c57398e478F855Fbe31dc500C030F85BE",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_rootApplication",
-              "type": "address",
-              "internalType": "contract ITACoChildToRoot"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "OwnableInvalidOwner",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "OwnableUnauthorizedAccount",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorConfirmed",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorUpdated",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OwnershipTransferred",
-          "inputs": [
-            {
-              "name": "previousOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "confirmOperatorAddress",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "owner",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "renounceOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "rootApplication",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract ITACoChildToRoot"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "setRootApplication",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "application",
-              "type": "address",
-              "internalType": "contract ITACoChildToRoot"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "transferOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "updateAuthorization",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "updateOperator",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        }
-      ],
-      "tx_hash": "0x4b17504b2177768291c281118aa596245a20969550c646bfedf59ff6dfa88c1e",
-      "block_number": 10054994,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "TACoApplication": {
-      "address": "0x31F0a0B94C829Ba6d902c98CAF8d8462C6c63241",
-      "abi": [
-        {
-          "type": "constructor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_token",
-              "type": "address",
-              "internalType": "contract IERC20"
-            },
-            {
-              "name": "_tStaking",
-              "type": "address",
-              "internalType": "contract IStaking"
-            },
-            {
-              "name": "_minimumAuthorization",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_minOperatorSeconds",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "_rewardDuration",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "_deauthorizationDuration",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "_commitmentDurationOptions",
-              "type": "uint64[]",
-              "internalType": "uint64[]"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AddressEmptyCode",
-          "inputs": [
-            {
-              "name": "target",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "AddressInsufficientBalance",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "FailedInnerCall",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "InvalidInitialization",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "NotInitializing",
-          "inputs": []
-        },
-        {
-          "type": "error",
-          "name": "OwnableInvalidOwner",
-          "inputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "OwnableUnauthorizedAccount",
-          "inputs": [
-            {
-              "name": "account",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "SafeCastOverflowedUintDowncast",
-          "inputs": [
-            {
-              "name": "bits",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "value",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "error",
-          "name": "SafeERC20FailedOperation",
-          "inputs": [
-            {
-              "name": "token",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationDecreaseApproved",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "fromAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            },
-            {
-              "name": "toAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationDecreaseRequested",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "fromAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            },
-            {
-              "name": "toAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationIncreased",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "fromAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            },
-            {
-              "name": "toAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationInvoluntaryDecreased",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "fromAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            },
-            {
-              "name": "toAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "AuthorizationReSynchronized",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "fromAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            },
-            {
-              "name": "toAmount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "CommitmentMade",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "endCommitment",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Initialized",
-          "inputs": [
-            {
-              "name": "version",
-              "type": "uint64",
-              "internalType": "uint64",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorBonded",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "previousOperator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "startTimestamp",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OperatorConfirmed",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "OwnershipTransferred",
-          "inputs": [
-            {
-              "name": "previousOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RewardAdded",
-          "inputs": [
-            {
-              "name": "reward",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RewardDistributorSet",
-          "inputs": [
-            {
-              "name": "distributor",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RewardPaid",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "beneficiary",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "reward",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "RewardsWithdrawn",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "amount",
-              "type": "uint96",
-              "internalType": "uint96",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "event",
-          "name": "Slashed",
-          "inputs": [
-            {
-              "name": "stakingProvider",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "penalty",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            },
-            {
-              "name": "investigator",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "reward",
-              "type": "uint256",
-              "internalType": "uint256",
-              "indexed": false
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "REWARD_PER_TOKEN_MULTIPLIER",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "adjudicator",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "authorizationDecreaseRequested",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_fromAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_toAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "authorizationIncreased",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_fromAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_toAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "authorizationParameters",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "_minimumAuthorization",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "authorizationDecreaseDelay",
-              "type": "uint64",
-              "internalType": "uint64"
-            },
-            {
-              "name": "authorizationDecreaseChangePeriod",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "authorizedOverall",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "authorizedStake",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "availableRewards",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "bondOperator",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "childApplication",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract ITACoRootToChild"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "commitmentDurationOption1",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "commitmentDurationOption2",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "commitmentDurationOption3",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "commitmentDurationOption4",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "confirmOperatorAddress",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "deauthorizationDuration",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "finishAuthorizationDecrease",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "getActiveStakingProviders",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_startIndex",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "_maxStakingProviders",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "allAuthorizedTokens",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "activeStakingProviders",
-              "type": "bytes32[]",
-              "internalType": "bytes32[]"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getBeneficiary",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "beneficiary",
-              "type": "address",
-              "internalType": "address payable"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getOperatorFromStakingProvider",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "getStakingProvidersLength",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "initialize",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "involuntaryAuthorizationDecrease",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_fromAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_toAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "isAuthorized",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "isOperatorConfirmed",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool",
-              "internalType": "bool"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "lastTimeRewardApplicable",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "lastUpdateTime",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "makeCommitment",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_commitmentDuration",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "minOperatorSeconds",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "minimumAuthorization",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "owner",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "pendingAuthorizationDecrease",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "periodFinish",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "pushReward",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_reward",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "remainingAuthorizationDecreaseDelay",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "renounceOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "resynchronizeAuthorization",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "rewardDistributor",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rewardDuration",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rewardPerToken",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint160",
-              "internalType": "uint160"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rewardPerTokenStored",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint160",
-              "internalType": "uint160"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "rewardRateDecimals",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "setAdjudicator",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_adjudicator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setChildApplication",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_childApplication",
-              "type": "address",
-              "internalType": "contract ITACoRootToChild"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setRewardDistributor",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_rewardDistributor",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "slash",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_penalty",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_investigator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "stakingProviderFromOperator",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_operator",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviderInfo",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "operator",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "operatorConfirmed",
-              "type": "bool",
-              "internalType": "bool"
-            },
-            {
-              "name": "operatorStartTimestamp",
-              "type": "uint64",
-              "internalType": "uint64"
-            },
-            {
-              "name": "authorized",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "deauthorizing",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "endDeauthorization",
-              "type": "uint64",
-              "internalType": "uint64"
-            },
-            {
-              "name": "tReward",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "rewardPerTokenPaid",
-              "type": "uint160",
-              "internalType": "uint160"
-            },
-            {
-              "name": "endCommitment",
-              "type": "uint64",
-              "internalType": "uint64"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviders",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "tStaking",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract IStaking"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "token",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract IERC20"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transferOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "withdrawRewards",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        }
-      ],
-      "tx_hash": "0x146cf5298f981d9cf7480ee478da5069fca17f18658c7abdda2fc6abf3d2d869",
-      "block_number": 10054982,
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    },
-    "TestnetThresholdStaking": {
-      "address": "0xcdD63981c8f4a2A684d102f7d7693A1c326CDd33",
-      "abi": [
-        {
-          "type": "event",
-          "name": "OwnershipTransferred",
-          "inputs": [
-            {
-              "name": "previousOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            },
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address",
-              "indexed": true
-            }
-          ],
-          "anonymous": false
-        },
-        {
-          "type": "function",
-          "name": "application",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "contract IApplication"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "authorizationIncreased",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_fromAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_toAmount",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "authorizedStake",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "owner",
-          "stateMutability": "view",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "renounceOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "rolesOf",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "beneficiary",
-              "type": "address",
-              "internalType": "address payable"
-            },
-            {
-              "name": "authorizer",
-              "type": "address",
-              "internalType": "address"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "setApplication",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_application",
-              "type": "address",
-              "internalType": "contract IApplication"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setRoles",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setRoles",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_owner",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_beneficiary",
-              "type": "address",
-              "internalType": "address payable"
-            },
-            {
-              "name": "_authorizer",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "setStakes",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "_tStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_keepInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "_nuInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ],
-          "outputs": []
-        },
-        {
-          "type": "function",
-          "name": "stakedNu",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "uint256",
-              "internalType": "uint256"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakes",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "_stakingProvider",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "tStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "keepInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "nuInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "stakingProviderInfo",
-          "stateMutability": "view",
-          "inputs": [
-            {
-              "name": "",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "owner",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "beneficiary",
-              "type": "address",
-              "internalType": "address payable"
-            },
-            {
-              "name": "authorizer",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "tStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "keepInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            },
-            {
-              "name": "nuInTStake",
-              "type": "uint96",
-              "internalType": "uint96"
-            }
-          ]
-        },
-        {
-          "type": "function",
-          "name": "transferOwnership",
-          "stateMutability": "nonpayable",
-          "inputs": [
-            {
-              "name": "newOwner",
-              "type": "address",
-              "internalType": "address"
-            }
-          ],
-          "outputs": []
-        }
-      ],
-      "tx_hash": "0x1d2bd03c0a9204b8ec1aae6f10eed732699d91da7fe66e20adf154259fdff027",
-      "block_number": "9758696",
-      "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-    }
-  }
 }

--- a/deployment/constants.py
+++ b/deployment/constants.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-import deployment
 from ape import project
+
+import deployment
 
 DEPLOYMENT_DIR = Path(deployment.__file__).parent
 CONSTRUCTOR_PARAMS_DIR = DEPLOYMENT_DIR / "constructor_params"
@@ -23,6 +24,7 @@ LYNX_NODES = {
     "0xb15d5a4e2be34f4be154a1b08a94ab920ffd8a41": "0x890069745E9497C6f99Db68C4588deC5669F3d3E",
     "0x210eeac07542f815ebb6fd6689637d8ca2689392": "0xf48F720A2Ed237c24F5A7686543D90596bb8D44D",
     "0x48C8039c32F4c6f5cb206A5911C8Ae814929C16B": "0xce057adc39dcD1b3eA28661194E8963481CC48b2",
+    "0xE4c8d3bcf8C87D73CE38Ab2DC288d309072ee4E7": "0x81B6a7b73C270659D0DAb223Ef81f3b36b812466",
 }
 
 TAPIR_NODES = {

--- a/deployment/constructor_params/lynx/child.yml
+++ b/deployment/constructor_params/lynx/child.yml
@@ -14,9 +14,8 @@ constants:
 
 contracts:
   - MockPolygonChild
-  - LynxTACoChildApplication:
+  - TACoChildApplication:
       proxy:
-        contract_type: TACoChildApplication
       constructor:
         _rootApplication: $MockPolygonChild
         _minimumAuthorization: $FORTY_THOUSAND_TOKENS_IN_WEI_UNITS
@@ -28,7 +27,7 @@ contracts:
         constructor:
           _data: $encode:initialize,$ONE_HOUR_IN_SECONDS,$MAX_DKG_SIZE,$deployer
       constructor:
-        _application: $LynxTACoChildApplication
+        _application: $TACoChildApplication
         _currency: $LynxRitualToken
         _feeRatePerSecond: 1
   - GlobalAllowList:

--- a/scripts/lynx/deploy_child.py
+++ b/scripts/lynx/deploy_child.py
@@ -21,6 +21,13 @@ def main():
     ape-polygon               0.6.5
     ape-solidity              0.6.9
     eth-ape                   0.6.20
+
+    November 16, 2023, Update:
+    ape-etherscan             0.6.10
+    ape-infura                0.6.4
+    ape-polygon               0.6.6
+    ape-solidity              0.6.9
+    eth-ape                   0.6.20
     """
 
     deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)

--- a/scripts/lynx/deploy_child.py
+++ b/scripts/lynx/deploy_child.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from ape import project
+
 from deployment.constants import CONSTRUCTOR_PARAMS_DIR
 from deployment.params import Deployer
 
@@ -26,7 +27,7 @@ def main():
 
     mock_polygon_child = deployer.deploy(project.MockPolygonChild)
 
-    taco_child_application = deployer.deploy(project.LynxTACoChildApplication)
+    taco_child_application = deployer.deploy(project.TACoChildApplication)
 
     deployer.transact(mock_polygon_child.setChildApplication, taco_child_application.address)
 

--- a/scripts/lynx/deploy_root.py
+++ b/scripts/lynx/deploy_root.py
@@ -19,6 +19,13 @@ def main():
     ape-polygon               0.6.5
     ape-solidity              0.6.9
     eth-ape                   0.6.20
+
+    November 16, 2023, Update:
+    ape-etherscan             0.6.10
+    ape-infura                0.6.4
+    ape-polygon               0.6.6
+    ape-solidity              0.6.9
+    eth-ape                   0.6.20
     """
 
     deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)


### PR DESCRIPTION
Based over #189 
=============

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Updated contracts on `lynx` to based on changes up to https://github.com/nucypher/nucypher-contracts/commit/820b8a40769a299db4f06462689de5cf0214f3bd.

Steps (custom changes, not to be committed, are catalogued here - https://github.com/derekpierre/nucypher-contracts/commits/david-derek-lynx-update):
- Modified lynx deployment scripts (root and child) to deploy updated MockPolygonRoot, TACoApplication (proxied), TACoChildApplication (proxied), Coordinator (proxied), GlobalAllowList, but reuse existing Lynx[Ritual/Staking]Token, TestnetThresholdStaking, MockPolygonChild contracts. See https://github.com/derekpierre/nucypher-contracts/commit/0234cdf79b1bc1f5a085a46efc1671945684d46c
- Merged resulting contract registry with existing lynx.json contract registry using the command:
```
$ ape run merge_registries --registry-1 ./deployment/artifacts/lynx.json --registry-2 ./deployment/artifacts/updated-lynx.json --output-registry ./deployment/artifacts/merged-lynx.json --deprecated-contract ProxyAdmin --deprecated-contract LynxTACoChildApplication --deprecated-contract TransparentUpgradeableProxy
```
- Modified `configure_staking` script and ran it to only perform `authorizationIncreased` and `bondOperator` on Goerli, and `updateAuthorization` and `updateOperator` on Mumbai, since application contracts were new - see https://github.com/derekpierre/nucypher-contracts/commit/8c1fc0e87ad3b3fec0457147f57781f9d09fe170
- Ran `confirm_operator_addresses` script as is.


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

On a related note - `nucpyher/nucypher` will need to include the updated lynx.json contract registry before updating lynx nodes - related PR is TBD (cc @cygnusv )
