### PR TITLE
StakingEscrow: removes unused code

### DIFF
--- a/contracts/test/StakingEscrowTestSet.sol
+++ b/contracts/test/StakingEscrowTestSet.sol
@@ -48,6 +48,11 @@ contract EnhancedStakingEscrow is StakingEscrow {
         stakers.push(_staker);
     }
 
+    function setStakingProvider(address _staker, address _stakingProvider) external {
+        StakerInfo storage info = stakerInfo[_staker];
+        info.stakingProvider = _stakingProvider;
+    }
+
 }
 
 
@@ -155,68 +160,22 @@ contract ThresholdStakingForStakingEscrowMock {
     IERC20 public immutable tToken;
     StakingEscrow public escrow;
 
-    struct StakingProviderInfo {
-        uint256 staked;
-        uint96 minStaked;
-    }
-
-    mapping(address => StakingProviderInfo) public stakingProviders;
+    mapping(address => uint256) public stakingProviders;
 
     constructor(IERC20 _tToken) {
         tToken = _tToken;
     }
 
+    function getApplicationsLength() external pure returns (uint256) {
+        return 1;
+    }
+
     function setStakingEscrow(StakingEscrow _escrow) external {
         escrow = _escrow;
     }
-
-    function stakedNu(address _stakingProvider) external view returns (uint256) {
-        return stakingProviders[_stakingProvider].staked;
-    }
-
-    function getMinStaked(address _stakingProvider, IStaking.StakeType _stakeTypes) external view returns (uint96) {
-        require(_stakeTypes == IStaking.StakeType.NU);
-        return stakingProviders[_stakingProvider].minStaked;
-    }
-
-    function stakes(address _stakingProvider) external view returns
-    (
-        uint96 tStake,
-        uint96 keepInTStake,
-        uint96 nuInTStake
-    ) {
-        tStake = 0;
-        keepInTStake = 0;
-        nuInTStake = uint96(stakingProviders[_stakingProvider].staked);
-    }
-
-    function slashStaker(
-        address _staker,
-        uint256 _penalty,
-        address _investigator,
-        uint256 _reward
-    )
-        external
-    {
-        escrow.slashStaker(_staker, _penalty, _investigator, _reward);
-    }
-
-    function requestMerge(address _staker, address _stakingProvider) external {
-        stakingProviders[_stakingProvider].staked = escrow.requestMerge(_staker, _stakingProvider);
-    }
-
-    function setStakedNu(address _stakingProvider, uint256 _staked) external {
-        require(_staked <= stakingProviders[_stakingProvider].staked);
-        stakingProviders[_stakingProvider].staked = _staked;
-    }
-
-    function setMinStaked(address _stakingProvider, uint96 _minStaked) external {
-        require(_minStaked <= stakingProviders[_stakingProvider].staked);
-        stakingProviders[_stakingProvider].minStaked = _minStaked;
-    }
     
     function topUp(address _stakingProvider, uint96 _amount) external {
-        stakingProviders[_stakingProvider].staked += _amount;
+        stakingProviders[_stakingProvider] += _amount;
         tToken.transferFrom(msg.sender, address(this), _amount);
     }
 }

--- a/tests/staking_escrow/test_staking_escrow.py
+++ b/tests/staking_escrow/test_staking_escrow.py
@@ -81,136 +81,6 @@ def test_staking_from_worklock(project, accounts, token, worklock, escrow):
     assert events == [escrow.Deposited(staker=staker3, value=value)]
 
 
-def test_slashing(accounts, token, worklock, threshold_staking, escrow):
-    creator = accounts[0]
-    staker = accounts[1]
-    investigator = accounts[2]
-
-    # Staker deposits some tokens
-    stake = Web3.to_wei(15_000, "ether")  # TODO
-    token.transfer(worklock.address, 10 * stake, sender=creator)
-    worklock.depositFromWorkLock(staker, stake, 0, sender=creator)
-
-    assert stake == escrow.getAllTokens(staker)
-
-    reward = stake // 100
-    # Can't slash directly using the escrow contract
-    with ape.reverts():
-        escrow.slashStaker(staker, stake, investigator, reward, sender=creator)
-    # Penalty must be greater than zero
-    with ape.reverts():
-        threshold_staking.slashStaker(staker, 0, investigator, 0, sender=creator)
-
-    # Slash the whole stake
-    tx = threshold_staking.slashStaker(staker, 2 * stake, investigator, reward, sender=creator)
-    # Staker has no more stake
-    assert escrow.getAllTokens(staker) == 0
-    assert token.balanceOf(investigator) == reward
-
-    events = escrow.Slashed.from_receipt(tx)
-    assert events == [
-        escrow.Slashed(staker=staker, penalty=stake, investigator=investigator, reward=reward)
-    ]
-
-    # Slash small part
-    worklock.depositFromWorkLock(staker, stake, 0, sender=creator)
-    amount_to_slash = stake // 10
-    tx = threshold_staking.slashStaker(
-        staker, amount_to_slash, investigator, 2 * amount_to_slash, sender=creator
-    )
-    # Staker has no more stake
-    assert escrow.getAllTokens(staker) == stake - amount_to_slash
-    assert token.balanceOf(investigator) == reward + amount_to_slash
-
-    events = escrow.Slashed.from_receipt(tx)
-    assert events == [
-        escrow.Slashed(
-            staker=staker,
-            penalty=amount_to_slash,
-            investigator=investigator,
-            reward=amount_to_slash,
-        )
-    ]
-
-    # Slash without reward
-    tx = threshold_staking.slashStaker(staker, amount_to_slash, investigator, 0, sender=creator)
-    # Staker has no more stake
-    assert escrow.getAllTokens(staker) == stake - 2 * amount_to_slash
-    assert token.balanceOf(investigator) == reward + amount_to_slash
-
-    events = escrow.Slashed.from_receipt(tx)
-    assert events == [
-        escrow.Slashed(staker=staker, penalty=amount_to_slash, investigator=investigator, reward=0)
-    ]
-
-
-def test_request_merge(accounts, threshold_staking, escrow):
-    creator, staker1, staker2, staking_provider_1, staking_provider_2 = accounts[0:5]
-
-    # Can't request merge directly
-    with ape.reverts():
-        escrow.requestMerge(staker1, staking_provider_1, sender=creator)
-
-    # Requesting merge for non-existent staker will return zero
-    tx = threshold_staking.requestMerge(staker1, staking_provider_1, sender=creator)
-    assert escrow.getAllTokens(staker1) == 0
-    assert escrow.stakerInfo(staker1)[STAKING_PROVIDER_SLOT] == staking_provider_1
-    assert threshold_staking.stakingProviders(staking_provider_1)[0] == 0
-
-    assert tx.events == [escrow.MergeRequested(staker=staker1, stakingProvider=staking_provider_1)]
-
-    # Request can be made several times
-    tx = threshold_staking.requestMerge(staker1, staking_provider_1, sender=creator)
-    assert escrow.getAllTokens(staker1) == 0
-    assert escrow.stakerInfo(staker1)[STAKING_PROVIDER_SLOT] == staking_provider_1
-    assert threshold_staking.stakingProviders(staking_provider_1)[0] == 0
-    assert tx.events == []
-
-    # Can change provider if old provider has no delegated stake
-    tx = threshold_staking.requestMerge(staker1, staker1, sender=creator)
-    assert escrow.getAllTokens(staker1) == 0
-    assert escrow.stakerInfo(staker1)[STAKING_PROVIDER_SLOT] == staker1
-    assert threshold_staking.stakingProviders(staking_provider_1)[0] == 0
-
-    assert tx.events == [escrow.MergeRequested(staker=staker1, stakingProvider=staker1)]
-
-    # Requesting merge for existent staker will return stake
-    value = 1000
-    escrow.setStaker(staker2, value, 0, sender=creator)
-    tx = threshold_staking.requestMerge(staker2, staking_provider_2, sender=creator)
-    assert escrow.getAllTokens(staker2) == value
-    assert escrow.stakerInfo(staker2)[STAKING_PROVIDER_SLOT] == staking_provider_2
-    assert threshold_staking.stakingProviders(staking_provider_2)[0] == value
-
-    assert tx.events == [escrow.MergeRequested(staker=staker2, stakingProvider=staking_provider_2)]
-
-    # Request can be made several times
-    threshold_staking.requestMerge(staker2, staking_provider_2, sender=creator)
-    assert escrow.getAllTokens(staker2) == value
-    assert escrow.stakerInfo(staker2)[STAKING_PROVIDER_SLOT] == staking_provider_2
-    assert threshold_staking.stakingProviders(staking_provider_2)[0] == value
-
-    escrow.setStaker(staker2, 2 * value, 0, sender=creator)
-    tx = threshold_staking.requestMerge(staker2, staking_provider_2, sender=creator)
-    assert escrow.getAllTokens(staker2) == 2 * value
-    assert escrow.stakerInfo(staker2)[STAKING_PROVIDER_SLOT] == staking_provider_2
-    assert threshold_staking.stakingProviders(staking_provider_2)[0] == 2 * value
-    assert tx.events == []
-
-    # Request can be done only with the same provider when NU is staked
-    with ape.reverts():
-        threshold_staking.requestMerge(staker2, staking_provider_1, sender=creator)
-
-    # Unstake NU and try again
-    threshold_staking.setStakedNu(staking_provider_2, 0, sender=creator)
-    tx = threshold_staking.requestMerge(staker2, staking_provider_1, sender=creator)
-    assert escrow.getAllTokens(staker2) == 2 * value
-    assert escrow.stakerInfo(staker2)[STAKING_PROVIDER_SLOT] == staking_provider_1
-    assert threshold_staking.stakingProviders(staking_provider_1)[0] == 2 * value
-
-    assert tx.events == [escrow.MergeRequested(staker=staker2, stakingProvider=staking_provider_1)]
-
-
 def test_withdraw(accounts, token, worklock, threshold_staking, escrow, chain):
     creator, staker, staking_provider = accounts[0:3]
 
@@ -221,55 +91,6 @@ def test_withdraw(accounts, token, worklock, threshold_staking, escrow, chain):
     token.transfer(worklock.address, 10 * value, sender=creator)
     worklock.depositFromWorkLock(staker, value + 1, 0, sender=creator)
 
-    # Withdraw without requesting merge
-    tx = escrow.withdraw(1, sender=staker)
-    assert escrow.getAllTokens(staker) == value
-    assert token.balanceOf(staker) == 1
-    assert token.balanceOf(escrow.address) == value
-
-    events = escrow.Withdrawn.from_receipt(tx)
-    assert events == [escrow.Withdrawn(staker=staker, value=1)]
-
-    threshold_staking.requestMerge(staker, staking_provider, sender=creator)
-
-    # Can't withdraw because everything is staked
-    with ape.reverts():
-        escrow.withdraw(1, sender=staker)
-
-    # Set vesting for the staker
-    threshold_staking.setStakedNu(staking_provider, value // 2, sender=creator)
-    now = chain.pending_timestamp
-    release_timestamp = now + ONE_HOUR
-    rate = 2 * value // ONE_HOUR
-    escrow.setupVesting([staker], [release_timestamp], [rate], sender=creator)
-
-    # Vesting parameters prevent from withdrawing
-    with ape.reverts():
-        escrow.withdraw(1, sender=staker)
-
-    # Wait some time
-    chain.pending_timestamp += 40 * 60
-    released = value - escrow.getUnvestedTokens(staker)
-
-    # Can't withdraw more than released
-    to_withdraw = released
-    with ape.reverts():
-        escrow.withdraw(to_withdraw + rate + 1, sender=staker)
-
-    tx = escrow.withdraw(to_withdraw, sender=staker)
-    assert escrow.getAllTokens(staker) == value - to_withdraw
-    assert token.balanceOf(staker) == to_withdraw + 1
-    assert token.balanceOf(escrow.address) == value - to_withdraw
-
-    events = escrow.Withdrawn.from_receipt(tx)
-    assert events == [escrow.Withdrawn(staker=staker, value=to_withdraw)]
-
-    # Can't withdraw more than unstaked
-    chain.pending_timestamp += 30 * 60
-    unstaked = value // 2 - to_withdraw
-    with ape.reverts():
-        escrow.withdraw(unstaked + 1, sender=staker)
-
     # Can't withdraw 0 tokens
     with ape.reverts():
         escrow.withdraw(0, sender=staker)
@@ -278,161 +99,14 @@ def test_withdraw(accounts, token, worklock, threshold_staking, escrow, chain):
     with ape.reverts():
         escrow.withdraw(1, sender=staking_provider)
 
-    tx = escrow.withdraw(unstaked, sender=staker)
-    assert escrow.getAllTokens(staker) == value // 2
-    assert token.balanceOf(staker) == value // 2 + 1
-    assert token.balanceOf(escrow.address) == value // 2
+    # Withdraw
+    tx = escrow.withdraw(1, sender=staker)
+    assert escrow.getAllTokens(staker) == value
+    assert token.balanceOf(staker) == 1
+    assert token.balanceOf(escrow.address) == value
 
     events = escrow.Withdrawn.from_receipt(tx)
-    assert events == [escrow.Withdrawn(staker=staker, value=unstaked)]
-
-    # Now unstake and withdraw everything
-    threshold_staking.setStakedNu(staking_provider, 0, sender=creator)
-    tx = escrow.withdraw(value // 2, sender=staker)
-    assert escrow.getAllTokens(staker) == 0
-    assert token.balanceOf(staker) == value + 1
-    assert token.balanceOf(escrow.address) == 0
-
-    events = escrow.Withdrawn.from_receipt(tx)
-    assert events == [escrow.Withdrawn(staker=staker, value=value // 2)]
-
-
-def test_vesting(accounts, token, worklock, escrow, chain):
-    creator, staker1, staker2, staker3, staker4 = accounts[0:5]
-
-    value = Web3.to_wei(15_000, "ether")  # TODO
-    token.transfer(worklock.address, 10 * value, sender=creator)
-    worklock.depositFromWorkLock(staker1, value, 0, sender=creator)
-
-    now = chain.pending_timestamp
-    release_timestamp = now + ONE_HOUR
-    rate = 2 * value // ONE_HOUR
-
-    # Only owner can set vesting parameters
-    with ape.reverts():
-        escrow.setupVesting([staker1], [release_timestamp], [rate], sender=staker1)
-
-    # All input arrays must have same number of values
-    with ape.reverts():
-        escrow.setupVesting(
-            [staker1, staker2], [release_timestamp, release_timestamp], [rate], sender=creator
-        )
-    with ape.reverts():
-        escrow.setupVesting([staker1, staker2], [release_timestamp], [rate, rate], sender=creator)
-    with ape.reverts():
-        escrow.setupVesting(
-            [staker1], [release_timestamp, release_timestamp], [rate, rate], sender=creator
-        )
-
-    # At least some amount of tokens must be locked after setting parameters
-    with ape.reverts():
-        escrow.setupVesting([staker1], [now], [rate], sender=creator)
-    with ape.reverts():
-        escrow.setupVesting(
-            [staker1, staker2],
-            [release_timestamp, release_timestamp],
-            [rate, rate],
-            sender=creator,
-        )
-
-    tx = escrow.setupVesting([staker1], [release_timestamp], [rate], sender=creator)
-    assert escrow.getUnvestedTokens(staker1) == value
-    assert escrow.stakerInfo(staker1)[VESTING_RELEASE_TIMESTAMP_SLOT] == release_timestamp
-    assert escrow.stakerInfo(staker1)[VESTING_RELEASE_RATE_SLOT] == rate
-
-    assert tx.events == [
-        escrow.VestingSet(staker=staker1, releaseTimestamp=release_timestamp, releaseRate=rate)
-    ]
-
-    chain.pending_timestamp += 40 * 60
-    now = chain.pending_timestamp - 1
-    vested = (release_timestamp - now) * rate
-    assert escrow.getUnvestedTokens(staker1) == vested
-
-    chain.pending_timestamp += 20 * 60
-    assert escrow.getUnvestedTokens(staker1) == 0
-
-    # Can't set vesting again even after unlocking
-    with ape.reverts():
-        escrow.setupVesting([staker1], [release_timestamp], [rate], sender=creator)
-
-    # Try again with three other stakers
-    value = Web3.to_wei(
-        ONE_HOUR, "ether"
-    )  # Exclude rounding error  # TODO NU(ONE_HOUR, 'NU').to_units()
-    worklock.depositFromWorkLock(staker2, value, 0, sender=creator)
-    worklock.depositFromWorkLock(staker3, value, 0, sender=creator)
-    worklock.depositFromWorkLock(staker4, value, 0, sender=creator)
-
-    now = chain.pending_timestamp
-    release_timestamp_2 = now + ONE_HOUR
-    release_timestamp_3 = now + 2 * ONE_HOUR
-    release_timestamp_4 = now + 2 * ONE_HOUR
-    rate_2 = value // ONE_HOUR // 2
-    rate_3 = value // ONE_HOUR // 4
-    rate_4 = 0
-    tx = escrow.setupVesting(
-        [staker2, staker3, staker4],
-        [release_timestamp_2, release_timestamp_3, release_timestamp_4],
-        [rate_2, rate_3, rate_4],
-        sender=creator,
-    )
-
-    assert escrow.getUnvestedTokens(staker2) == value // 2
-    assert escrow.getUnvestedTokens(staker3) == value // 2
-    assert escrow.getUnvestedTokens(staker4) == value
-    assert escrow.stakerInfo(staker2)[VESTING_RELEASE_TIMESTAMP_SLOT] == release_timestamp_2
-    assert escrow.stakerInfo(staker2)[VESTING_RELEASE_RATE_SLOT] == rate_2
-    assert escrow.stakerInfo(staker3)[VESTING_RELEASE_TIMESTAMP_SLOT] == release_timestamp_3
-    assert escrow.stakerInfo(staker3)[VESTING_RELEASE_RATE_SLOT] == rate_3
-    assert escrow.stakerInfo(staker4)[VESTING_RELEASE_TIMESTAMP_SLOT] == release_timestamp_4
-    assert escrow.stakerInfo(staker4)[VESTING_RELEASE_RATE_SLOT] == rate_4
-
-    assert tx.events == [
-        escrow.VestingSet(staker=staker2, releaseTimestamp=release_timestamp_2, releaseRate=rate_2),
-        escrow.VestingSet(staker=staker3, releaseTimestamp=release_timestamp_3, releaseRate=rate_3),
-        escrow.VestingSet(staker=staker4, releaseTimestamp=release_timestamp_4, releaseRate=rate_4),
-    ]
-
-    chain.pending_timestamp += ONE_HOUR
-    assert escrow.getUnvestedTokens(staker2) == 0
-    assert escrow.getUnvestedTokens(staker3) == value // 4
-    assert escrow.getUnvestedTokens(staker4) == value
-
-    chain.pending_timestamp += ONE_HOUR
-    assert escrow.getUnvestedTokens(staker2) == 0
-    assert escrow.getUnvestedTokens(staker3) == 0
-    assert escrow.getUnvestedTokens(staker4) == 0
-
-
-def test_combined_vesting(accounts, token, worklock, escrow, chain):
-    staker = "0xcd087a44ED8EE2aCe79F497c803005Ff79A64A94"
-    value = Web3.to_wei(1_500_000, "ether")  # TODO
-
-    creator = accounts[0]
-
-    token.transfer(worklock.address, 10 * value, sender=creator)
-    worklock.depositFromWorkLock(staker, 3 * value, 0, sender=creator)
-
-    now = chain.pending_timestamp
-    release_timestamp = now + ONE_HOUR
-    rate = 0
-
-    tx = escrow.setupVesting([staker], [release_timestamp], [rate], sender=creator)
-    assert escrow.getUnvestedTokens(staker) == value
-    assert escrow.stakerInfo(staker)[VESTING_RELEASE_TIMESTAMP_SLOT] == release_timestamp
-    assert escrow.stakerInfo(staker)[VESTING_RELEASE_RATE_SLOT] == rate
-
-    assert tx.events == [
-        escrow.VestingSet(staker=staker, releaseTimestamp=release_timestamp, releaseRate=rate)
-    ]
-
-    chain.pending_timestamp += 40 * 60
-    now = chain.pending_timestamp - 1
-    assert escrow.getUnvestedTokens(staker) == value
-
-    chain.pending_timestamp += 20 * 60
-    assert escrow.getUnvestedTokens(staker) == 0
+    assert events == [escrow.Withdrawn(staker=staker, value=1)]
 
 
 def test_wrap(
@@ -452,21 +126,7 @@ def test_wrap(
     with ape.reverts():
         escrow.wrapAndTopUp(sender=staker)
 
-    threshold_staking.requestMerge(staker, staking_provider, sender=creator)
-
-    with ape.reverts():
-        escrow.wrapAndTopUp(sender=staker)
-
-    threshold_staking.setStakedNu(staking_provider, 0, sender=creator)
-    now = chain.pending_timestamp
-    release_timestamp = now + ONE_HOUR
-    rate = value // ONE_HOUR
-    escrow.setupVesting([staker], [release_timestamp], [rate], sender=creator)
-
-    with ape.reverts():
-        escrow.wrapAndTopUp(sender=staker)
-
-    chain.pending_timestamp += ONE_HOUR
+    escrow.setStakingProvider(staker, staking_provider, sender=creator)
 
     tx = escrow.wrapAndTopUp(sender=staker)
     assert escrow.getAllTokens(staker) == 0
@@ -482,8 +142,7 @@ def test_wrap(
     # Wrap again but with remainder
     other_value = Web3.to_wei(15_000, "ether") + 1
     worklock.depositFromWorkLock(other_staker, other_value, 0, sender=creator)
-    threshold_staking.requestMerge(other_staker, other_staker, sender=creator)
-    threshold_staking.setStakedNu(other_staker, 0, sender=creator)
+    escrow.setStakingProvider(other_staker, other_staker, sender=creator)
 
     tx = escrow.wrapAndTopUp(sender=other_staker)
     expected_value = value + other_value - 1


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Now when all legacy tokens unstaked we can remove unused parts of code which will allow to clean `TokenStaking` contract
