### PR TITLE
Return minimumAuthorization instead of _minimumAuthorization

### DIFF
--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -300,7 +300,7 @@ contract TACoApplication is
      *  @notice Returns authorization-related parameters of the application.
      *  @dev The minimum authorization is also returned by `minimumAuthorization()`
      *       function, as a requirement of `IApplication` interface.
-     *  @return _minimumAuthorization The minimum authorization amount required
+     *  @return minimumAuthorization The minimum authorization amount required
      *          so that operator can participate in the application.
      *  @return authorizationDecreaseDelay Delay in seconds that needs to pass
      *          between the time authorization decrease is requested and the
@@ -320,7 +320,7 @@ contract TACoApplication is
         view
         override
         returns (
-            uint96 _minimumAuthorization,
+            uint96 minimumAuthorization,
             uint64 authorizationDecreaseDelay,
             uint64 authorizationDecreaseChangePeriod
         )


### PR DESCRIPTION
Fixes #213

**Type of PR:**
- [x] Bugfix

**Required reviews:** 
- [x] 1

variables prefixed with underscores are for internal use, an `external` `view` function should return variables without the underscore prefix