### PR TITLE
Fix for PolygonChild initiation and manual sync method for TACo app

### DIFF
--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -292,7 +292,6 @@ contract TACoApplication is
      * @notice Set contract for multi-chain interactions
      */
     function setChildApplication(ITACoRootToChild _childApplication) external onlyOwner {
-        require(address(childApplication) == address(0), "Child application is already set");
         require(address(_childApplication).code.length > 0, "Child app must be contract");
         childApplication = _childApplication;
     }

--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -144,8 +144,8 @@ contract TACoApplication is
     /**
      * @notice Signals that manual child synchronization was called
      * @param stakingProvider Staking provider address
-     * @param authorized Previous amount of authorized tokens
-     * @param operator Resynchronized amount of authorized tokens
+     * @param authorized Amount of authorized tokens to synchronize
+     * @param operator Operator address to synchronize
      */
     event ManualChildSynchronizationSent(
         address indexed stakingProvider,
@@ -881,7 +881,7 @@ contract TACoApplication is
 
     /**
      * @notice Manual signal to the bridge with the current state of the specified staking provider
-     * @dev This method useful only in case of issues with the bridge
+     * @dev This method is useful only in case of issues with the bridge
      */
     function manualChildSynchronization(address _stakingProvider) external {
         require(_stakingProvider != address(0), "Staking provider must be specified");

--- a/contracts/test/CoordinatorTestSet.sol
+++ b/contracts/test/CoordinatorTestSet.sol
@@ -11,14 +11,14 @@ contract ChildApplicationForCoordinatorMock is ITACoChildApplication {
     uint96 public minimumAuthorization = 0;
 
     mapping(address => uint96) public authorizedStake;
-    mapping(address => address) public operatorFromStakingProvider;
+    mapping(address => address) public stakingProviderToOperator;
     mapping(address => address) public operatorToStakingProvider;
     mapping(address => bool) public confirmations;
 
     function updateOperator(address _stakingProvider, address _operator) external {
-        address oldOperator = operatorFromStakingProvider[_stakingProvider];
+        address oldOperator = stakingProviderToOperator[_stakingProvider];
         operatorToStakingProvider[oldOperator] = address(0);
-        operatorFromStakingProvider[_stakingProvider] = _operator;
+        stakingProviderToOperator[_stakingProvider] = _operator;
         operatorToStakingProvider[_operator] = _stakingProvider;
     }
 

--- a/contracts/test/TACoApplicationTestSet.sol
+++ b/contracts/test/TACoApplicationTestSet.sol
@@ -147,7 +147,7 @@ contract ChildApplicationForTACoApplicationMock {
     TACoApplication public immutable rootApplication;
 
     mapping(address => uint96) public authorizedStake;
-    mapping(address => address) public operatorFromStakingProvider;
+    mapping(address => address) public stakingProviderToOperator;
     mapping(address => address) public operatorToStakingProvider;
 
     constructor(TACoApplication _rootApplication) {
@@ -155,9 +155,9 @@ contract ChildApplicationForTACoApplicationMock {
     }
 
     function updateOperator(address _stakingProvider, address _operator) external {
-        address oldOperator = operatorFromStakingProvider[_stakingProvider];
+        address oldOperator = stakingProviderToOperator[_stakingProvider];
         operatorToStakingProvider[oldOperator] = address(0);
-        operatorFromStakingProvider[_stakingProvider] = _operator;
+        stakingProviderToOperator[_stakingProvider] = _operator;
         operatorToStakingProvider[_operator] = _stakingProvider;
     }
 

--- a/contracts/xchain/PolygonChild.sol
+++ b/contracts/xchain/PolygonChild.sol
@@ -23,11 +23,16 @@ contract PolygonChild is FxBaseChildTunnel, Ownable {
     function setFxRootTunnel(address _fxRootTunnel) external override onlyOwner {
         require(fxRootTunnel == address(0x0), "FxBaseChildTunnel: ROOT_TUNNEL_ALREADY_SET");
         fxRootTunnel = _fxRootTunnel;
+        if (childApplication != address(0)) {
+            renounceOwnership();
+        }
     }
 
     function setChildApplication(address _childApplication) public onlyOwner {
         childApplication = _childApplication;
-        renounceOwnership();
+        if (fxRootTunnel != address(0)) {
+            renounceOwnership();
+        }
     }
 
     fallback() external {

--- a/deployment/artifacts/mainnet-child-repair.json
+++ b/deployment/artifacts/mainnet-child-repair.json
@@ -1,0 +1,540 @@
+{
+    "137": {
+        "PolygonChild": {
+            "address": "0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_fxChild",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableInvalidOwner",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "MessageSent",
+                    "inputs": [
+                        {
+                            "name": "message",
+                            "type": "bytes",
+                            "internalType": "bytes",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "fallback",
+                    "stateMutability": "nonpayable"
+                },
+                {
+                    "type": "function",
+                    "name": "childApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "fxChild",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "fxRootTunnel",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "processMessageFromRoot",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stateId",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "rootMessageSender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "data",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setChildApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_childApplication",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setFxRootTunnel",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_fxRootTunnel",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0xad8835aa771ea9d0038a54f8065d6b0b2d3d1e592b817aa2932ce763e35f9f60",
+            "block_number": 50816123,
+            "deployer": "0x1591165F1BF8B73de7053A6BE6f239BC15076879"
+        },
+        "TACoChildApplication": {
+            "address": "0x1482B3897ff429e78F0ec0957058c7258c46d2ED",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rootApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        },
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getStakingProvidersLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "minimumAuthorization",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "operatorToStakingProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rootApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "operatorConfirmed",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "index",
+                            "type": "uint248",
+                            "internalType": "uint248"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x02083e15144c13678520da32698415bf409acc26436b1e155ed9aa5dd5052e2a",
+            "block_number": 50816169,
+            "deployer": "0x1591165F1BF8B73de7053A6BE6f239BC15076879"
+        }
+    }
+}

--- a/deployment/artifacts/mainnet-root-repair.json
+++ b/deployment/artifacts/mainnet-root-repair.json
@@ -1,0 +1,1542 @@
+{
+    "1": {
+        "PolygonRoot": {
+            "address": "0x51825d6e893c51836dC9C0EdF3867c57CD0cACB3",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_checkpointManager",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fxRoot",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_rootApplication",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fxChildTunnel",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "fallback",
+                    "stateMutability": "nonpayable"
+                },
+                {
+                    "type": "function",
+                    "name": "SEND_MESSAGE_EVENT_SIG",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "checkpointManager",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ICheckpointManager"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "fxChildTunnel",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "fxRoot",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IFxStateSender"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "processedExits",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "receiveMessage",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "inputData",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rootApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "setFxChildTunnel",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_fxChildTunnel",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x6f312fa728d914beabdb6164ccc5863c869874957318f8b6d618ac5448bec55a",
+            "block_number": 18728539,
+            "deployer": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50"
+        },
+        "TACoApplication": {
+            "address": "0x76e9e5A077eBa64862B5D1f94e534aCEc86854a8",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_token",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "_tStaking",
+                            "type": "address",
+                            "internalType": "contract IStaking"
+                        },
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_minOperatorSeconds",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_rewardDuration",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_deauthorizationDuration",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_commitmentDurationOptions",
+                            "type": "uint64[]",
+                            "internalType": "uint64[]"
+                        },
+                        {
+                            "name": "_commitmentDeadline",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressEmptyCode",
+                    "inputs": [
+                        {
+                            "name": "target",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressInsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "FailedInnerCall",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableInvalidOwner",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeCastOverflowedUintDowncast",
+                    "inputs": [
+                        {
+                            "name": "bits",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeERC20FailedOperation",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationDecreaseApproved",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationDecreaseRequested",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationIncreased",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationInvoluntaryDecreased",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationReSynchronized",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "CommitmentMade",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "endCommitment",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ManualChildSynchronizationSent",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorBonded",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousOperator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "startTimestamp",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardAdded",
+                    "inputs": [
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardDistributorSet",
+                    "inputs": [
+                        {
+                            "name": "distributor",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardPaid",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RewardsWithdrawn",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Slashed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "penalty",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        },
+                        {
+                            "name": "investigator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "reward",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "REWARD_PER_TOKEN_MULTIPLIER",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "adjudicator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "approveAuthorizationDecrease",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationDecreaseRequested",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationIncreased",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "authorizationParameters",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "authorizationDecreaseDelay",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "authorizationDecreaseChangePeriod",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedOverall",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "availableRewards",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "bondOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "childApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDeadline",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption1",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption2",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption3",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "commitmentDurationOption4",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "deauthorizationDuration",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getBeneficiary",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "beneficiary",
+                            "type": "address",
+                            "internalType": "address payable"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getStakingProvidersLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "involuntaryAuthorizationDecrease",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_fromAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_toAmount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isOperatorConfirmed",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "lastTimeRewardApplicable",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "lastUpdateTime",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "makeCommitment",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_commitmentDuration",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "manualChildSynchronization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "minOperatorSeconds",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "minimumAuthorization",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "operatorToStakingProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingAuthorizationDecrease",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "periodFinish",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pushReward",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_reward",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "registerOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "remainingAuthorizationDecreaseDelay",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "resynchronizeAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rewardDistributor",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardDuration",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardPerToken",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardPerTokenStored",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rewardRateDecimals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "setAdjudicator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_adjudicator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setChildApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_childApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setRewardDistributor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rewardDistributor",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "slash",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_penalty",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "_investigator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operatorConfirmed",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "operatorStartTimestamp",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        },
+                        {
+                            "name": "tReward",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "rewardPerTokenPaid",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                        },
+                        {
+                            "name": "endCommitment",
+                            "type": "uint64",
+                            "internalType": "uint64"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderToOperator",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "tStaking",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IStaking"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "token",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "withdrawRewards",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x47719dca373524d96bd046306f7829e3e576a1e20e0fc8db6f5974f0293b60bf",
+            "block_number": 18728528,
+            "deployer": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50"
+        }
+    }
+}

--- a/deployment/artifacts/mainnet.json
+++ b/deployment/artifacts/mainnet.json
@@ -1,7 +1,7 @@
 {
     "1": {
         "PolygonRoot": {
-            "address": "0xEc20eD1240F8AdC50c01bdcfe1B6f878Dc0fF583",
+            "address": "0x51825d6e893c51836dC9C0EdF3867c57CD0cACB3",
             "abi": [
                 {
                     "type": "constructor",
@@ -144,8 +144,8 @@
                     "outputs": []
                 }
             ],
-            "tx_hash": "0x9ac6aac59e58438b95884feed29c75cfa98bd9776ba4689bd27f1550564fbbb1",
-            "block_number": 18622379,
+            "tx_hash": "0x6f312fa728d914beabdb6164ccc5863c869874957318f8b6d618ac5448bec55a",
+            "block_number": 18728539,
             "deployer": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50"
         },
         "TACoApplication": {
@@ -435,6 +435,31 @@
                             "name": "version",
                             "type": "uint64",
                             "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ManualChildSynchronizationSent",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
                             "indexed": false
                         }
                     ],
@@ -1060,6 +1085,19 @@
                             "name": "_commitmentDuration",
                             "type": "uint64",
                             "internalType": "uint64"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "manualChildSynchronization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
                         }
                     ],
                     "outputs": []
@@ -3282,7 +3320,7 @@
             "deployer": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50"
         },
         "PolygonChild": {
-            "address": "0xa67B971011Ea3675449d8c054B243990B839afDd",
+            "address": "0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5",
             "abi": [
                 {
                     "type": "constructor",
@@ -3475,9 +3513,9 @@
                     "outputs": []
                 }
             ],
-            "tx_hash": "0x02af325b856288153717e76d3323aa8444ba28994c20ed0b313c260641115b3d",
-            "block_number": 50223971,
-            "deployer": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50"
+            "tx_hash": "0xad8835aa771ea9d0038a54f8065d6b0b2d3d1e592b817aa2932ce763e35f9f60",
+            "block_number": 50816123,
+            "deployer": "0x1591165F1BF8B73de7053A6BE6f239BC15076879"
         },
         "SubscriptionManager": {
             "address": "0xB0194073421192F6Cf38d72c791Be8729721A0b3",

--- a/deployment/constructor_params/mainnet/repair-child.yml
+++ b/deployment/constructor_params/mainnet/repair-child.yml
@@ -1,0 +1,41 @@
+deployment:
+  name: mainnet-child-repair
+  chain_id: 137  # Polygon Mainnet
+
+artifacts:
+  dir: ./deployment/artifacts/
+  filename: mainnet-child-repair.json
+
+constants:
+  # DAI Token on Polygon PoS - References:
+  # - https://polygonscan.com/token/0x8f3cf7ad23cd3cadbd9735aff958023239c6a063
+  # - https://github.com/search?q=0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063&type=code
+  DAI_ON_POLYGON: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+
+  # TACO specific constants:
+  PRIVATE_BETA_FEE_RATE: 4050925925925  # $0.35 per day, expressed in DAI units per seconds (in Python: 35*10**16 // 86400)
+  MAX_DKG_SIZE: 32
+  DKG_TIMEOUT_IN_SECONDS: 3600  # One hour in seconds
+  FORTY_THOUSAND_TOKENS_IN_WEI_UNITS: 40000000000000000000000
+
+  # Threshold Network - References:
+  # - https://docs.threshold.network/resources/contract-addresses/mainnet/threshold-dao
+  # - https://github.com/keep-network/tbtc-v2/issues/594
+  TREASURY_GUILD_ON_POLYGON: "0xc3Bf49eBA094AF346830dF4dbB42a07dE378EeB6"
+  INTEGRATIONS_GUILD_ON_POLYGON: "0x5bD70E385414C8dCC25305AeB7E542d8FC70e667"
+  THRESHOLD_COUNCIL_ON_POLYGON: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f"
+
+  # FxPortal addresses - References:
+  # - https://github.com/0xPolygon/fx-portal#deployment-addresses
+  # - https://github.com/0xPolygon/fx-portal/blob/main/config/config.json
+  # - https://wiki.polygon.technology/docs/pos/design/bridge/l1-l2-communication/state-transfer/#prerequisites
+  FXPORTAL_FXCHILD: "0x8397259c983751DAf40400790063935a11afa28a"
+
+contracts:
+  - PolygonChild:
+      constructor:
+        _fxChild: $FXPORTAL_FXCHILD
+  - TACoChildApplication:
+      constructor:
+        _rootApplication: $PolygonChild
+        _minimumAuthorization: $FORTY_THOUSAND_TOKENS_IN_WEI_UNITS

--- a/deployment/constructor_params/mainnet/repair-root.yml
+++ b/deployment/constructor_params/mainnet/repair-root.yml
@@ -1,0 +1,51 @@
+deployment:
+  name: mainnet-root-repair
+  chain_id: 1
+
+artifacts:
+  dir: ./deployment/artifacts/
+  filename: mainnet-root-repair.json
+
+constants:
+  # Threshold Network - References:
+  # - https://docs.threshold.network/resources/contract-addresses/mainnet/threshold-dao
+  T_TOKEN_ETH_MAINNET: "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5"
+  T_STAKING_CONTRACT: "0x01B67b1194C75264d06F808A921228a95C765dd7"
+
+  # FxPortal addresses - References:
+  # - https://github.com/0xPolygon/fx-portal#deployment-addresses
+  # - https://github.com/0xPolygon/fx-portal/blob/main/config/config.json
+  # - https://wiki.polygon.technology/docs/pos/design/bridge/l1-l2-communication/state-transfer/#prerequisites
+  FXPORTAL_CHECKPOINT_MANAGER: "0x86e4dc95c7fbdbf52e33d563bbdb00823894c287"
+  FXPORTAL_FXROOT: "0xfe5e5D361b2ad62c541bAb87C45a0B9B018389a2"
+  POLYGON_CHILD: "invalid" # Temporary invalid value that will be overwritten by workaround in deployment script
+
+  # TACo specific constants:
+  IN_SECONDS_1_DAY: 86400
+  IN_SECONDS_91_DAYS: 7862400
+  IN_SECONDS_182_DAYS: 15724800
+  IN_SECONDS_364_DAYS: 31449600
+  IN_SECONDS_546_DAYS: 47174400
+  IN_SECONDS_AVERAGE_MONTH_DURATION: 2628000  # 365*24*60*60/12
+  FORTY_THOUSAND_TOKENS_IN_WEI_UNITS: 40000000000000000000000
+  TIMESTAMP_FOR_2023_12_30_2359_UTC: 1703980799
+  TACO_APPLICATION_PROXY: "0x347CC7ede7e5517bD47D20620B2CF1b406edcF07"
+
+contracts:
+  - TACoApplication:
+      constructor:
+        _token: $T_TOKEN_ETH_MAINNET
+        _tStaking: $T_STAKING_CONTRACT
+        _minimumAuthorization: $FORTY_THOUSAND_TOKENS_IN_WEI_UNITS
+        _minOperatorSeconds: $IN_SECONDS_1_DAY
+        _rewardDuration: $IN_SECONDS_AVERAGE_MONTH_DURATION
+        _deauthorizationDuration: $IN_SECONDS_182_DAYS
+        _commitmentDurationOptions: [$IN_SECONDS_91_DAYS, $IN_SECONDS_182_DAYS, $IN_SECONDS_364_DAYS, $IN_SECONDS_546_DAYS]
+        _commitmentDeadline: $TIMESTAMP_FOR_2023_12_30_2359_UTC
+  - PolygonRoot:
+      constructor:
+        _checkpointManager: $FXPORTAL_CHECKPOINT_MANAGER
+        _fxRoot: $FXPORTAL_FXROOT
+        _rootApplication: $TACO_APPLICATION_PROXY
+        _fxChildTunnel: $POLYGON_CHILD  # This is a Polygon address
+

--- a/deployment/constructor_params/mainnet/repair-root.yml
+++ b/deployment/constructor_params/mainnet/repair-root.yml
@@ -16,7 +16,7 @@ constants:
   # - https://github.com/0xPolygon/fx-portal#deployment-addresses
   # - https://github.com/0xPolygon/fx-portal/blob/main/config/config.json
   # - https://wiki.polygon.technology/docs/pos/design/bridge/l1-l2-communication/state-transfer/#prerequisites
-  FXPORTAL_CHECKPOINT_MANAGER: "0x86e4dc95c7fbdbf52e33d563bbdb00823894c287"
+  FXPORTAL_CHECKPOINT_MANAGER: "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287"
   FXPORTAL_FXROOT: "0xfe5e5D361b2ad62c541bAb87C45a0B9B018389a2"
   POLYGON_CHILD: "invalid" # Temporary invalid value that will be overwritten by workaround in deployment script
 

--- a/deployment/constructor_params/mainnet/repair-root.yml
+++ b/deployment/constructor_params/mainnet/repair-root.yml
@@ -18,7 +18,7 @@ constants:
   # - https://wiki.polygon.technology/docs/pos/design/bridge/l1-l2-communication/state-transfer/#prerequisites
   FXPORTAL_CHECKPOINT_MANAGER: "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287"
   FXPORTAL_FXROOT: "0xfe5e5D361b2ad62c541bAb87C45a0B9B018389a2"
-  POLYGON_CHILD: "invalid" # Temporary invalid value that will be overwritten by workaround in deployment script
+  POLYGON_CHILD: "0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5"
 
   # TACo specific constants:
   IN_SECONDS_1_DAY: 86400

--- a/deployment/constructor_params/mainnet/root.yml
+++ b/deployment/constructor_params/mainnet/root.yml
@@ -13,7 +13,7 @@ constants:
   T_STAKING_CONTRACT: "0x01B67b1194C75264d06F808A921228a95C765dd7"
   THRESHOLD_COUNCIL_ETH_MAINNET: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f"
 
-  # FxPortal addresses - References:
+  # FxPortal addresses - References:
   # - https://github.com/0xPolygon/fx-portal#deployment-addresses
   # - https://github.com/0xPolygon/fx-portal/blob/main/config/config.json
   # - https://wiki.polygon.technology/docs/pos/design/bridge/l1-l2-communication/state-transfer/#prerequisites

--- a/deployment/params.py
+++ b/deployment/params.py
@@ -505,9 +505,9 @@ class Transactor:
         _continue()
 
         result = method(*args, sender=self._account,
-                        # FIXME
-                        max_priority_fee="10 gwei",
-                        max_fee="100 gwei"
+                        # FIXME: Manual gas fees - #199
+                        max_priority_fee="3 gwei",
+                        max_fee="120 gwei"
                         )
         return result
 
@@ -589,9 +589,9 @@ class Deployer(Transactor):
 
         deployer_account = self.get_account()
         return deployer_account.deploy(*deployment_params, 
-                                       # FIXME
-                                       max_priority_fee="10 gwei",
-                                       max_fee="100 gwei",
+                                       # FIXME: Manual gas fees - #199
+                                       max_priority_fee="3 gwei",
+                                       max_fee="120 gwei",
                                        **kwargs)
 
     def _deploy_proxy(

--- a/scripts/mainnet/deploy_root.py
+++ b/scripts/mainnet/deploy_root.py
@@ -15,27 +15,31 @@ def main():
     polygon_chain_id = 137
     polygon_child_name = "PolygonChild"
     polygon_childs = [
-        entry for entry in current_mainnet_registry
+        entry
+        for entry in current_mainnet_registry
         if entry.chain_id == polygon_chain_id and entry.name == polygon_child_name
     ]
     if len(polygon_childs) != 1:
         raise ValueError("Mainnet root deployment requires valid child deployment first")
-    
+
     deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)
 
     # TODO: Workaround to provide PolygonChild address from existing registry
     polygon_child = polygon_childs.pop()
-    deployer.constructor_parameters.parameters["PolygonRoot"]["_fxChildTunnel"] = polygon_child.address
+    deployer.constructor_parameters.parameters["PolygonRoot"][
+        "_fxChildTunnel"
+    ] = polygon_child.address
 
     taco_application = deployer.deploy(project.TACoApplication)
 
     polygon_root = deployer.deploy(project.PolygonRoot)
 
+    deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
+
     # Need to set child application before transferring ownership
     deployer.transact(taco_application.setChildApplication, polygon_root.address)
     deployer.transact(
-        taco_application.transferOwnership,
-        deployer.constants.THRESHOLD_COUNCIL_ETH_MAINNET
+        taco_application.transferOwnership, deployer.constants.THRESHOLD_COUNCIL_ETH_MAINNET
     )
 
     deployments = [

--- a/scripts/mainnet/deploy_root.py
+++ b/scripts/mainnet/deploy_root.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from ape import project
+from ape import project, networks
 
 from deployment.constants import ARTIFACTS_DIR, CONSTRUCTOR_PARAMS_DIR
 from deployment.params import Deployer
@@ -34,7 +34,10 @@ def main():
 
     polygon_root = deployer.deploy(project.PolygonRoot)
 
-    deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
+    # This line was missing from the original script
+    # with networks.polygon.mainnet.use_provider("infura"):
+    #     polygon_child = project.PolygonChild.at('invalid')
+    #     deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
 
     # Need to set child application before transferring ownership
     deployer.transact(taco_application.setChildApplication, polygon_root.address)

--- a/scripts/mainnet/repair_child.py
+++ b/scripts/mainnet/repair_child.py
@@ -12,7 +12,7 @@ CONSTRUCTOR_PARAMS_FILEPATH = CONSTRUCTOR_PARAMS_DIR / "mainnet" / "repair-child
 def main():
     """
     This script deploys latest TACoApplication and PolygonChild contracts on Polygon/Mainnet, setting
-    the PolygonChild's child application to the new TACoApplication contract.
+    the PolygonChild's child application to the existing TACoApplication proxy.
     """
 
     deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)

--- a/scripts/mainnet/repair_child.py
+++ b/scripts/mainnet/repair_child.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+from ape import project
+
+from deployment.constants import CONSTRUCTOR_PARAMS_DIR
+from deployment.params import Deployer
+
+VERIFY = False
+CONSTRUCTOR_PARAMS_FILEPATH = CONSTRUCTOR_PARAMS_DIR / "mainnet" / "repair-child.yml"
+
+
+def main():
+    """
+    This script deploys latest TACoApplication and PolygonChild contracts on Polygon/Mainnet, setting
+    the PolygonChild's child application to the new TACoApplication contract.
+    """
+
+    deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)
+
+    polygon_child = deployer.deploy(project.PolygonChild)
+
+    taco_child_application_implementation = deployer.deploy(project.TACoChildApplication)
+
+    taco_child_application_proxy = '0xFa07aaB78062Fac4C36995bF28F6D677667973F5'
+    deployer.transact(polygon_child.setChildApplication, taco_child_application_proxy)
+    # PolygonChild must set the root tunnel on the repair root script after deployment and upgrade
+
+    deployments = [
+        polygon_child,
+        taco_child_application_implementation,
+    ]
+
+    deployer.finalize(deployments=deployments)

--- a/scripts/mainnet/repair_root.py
+++ b/scripts/mainnet/repair_root.py
@@ -11,24 +11,19 @@ CONSTRUCTOR_PARAMS_FILEPATH = CONSTRUCTOR_PARAMS_DIR / "mainnet" / "repair-root.
 
 
 def main():
-    ethereum_network = networks.ethereum.mainnet
-    polygon_network = networks.polygon.mainnet
 
     deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)
 
-    with ethereum_network.use_provider("infura"):
-        taco_application_implementation = deployer.deploy(project.TACoApplication)
-        polygon_root = deployer.deploy(project.PolygonRoot)
+    taco_application_implementation = deployer.deploy(project.TACoApplication)
+    polygon_root = deployer.deploy(project.PolygonRoot)
 
-        # Council multisig upgrades TACoApplication with new implementation.
-        # Also, council must set the child application with new PolygonRoot
-        # deployer.transact(taco_application.setChildApplication, polygon_root.address)
+    # Council multisig upgrades TACoApplication with new implementation.
+    # Also, council must set the child application with new PolygonRoot
+    # deployer.transact(taco_application.setChildApplication, polygon_root.address)
 
-
-    with polygon_network.use_provider("infura"):
-        polygon_child = project.PolygonChild.at('invalid')
-        deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
-
+    # Pending steps to be performed in Polygon
+    #     polygon_child = project.PolygonChild.at('invalid')
+    #     deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
 
     deployments = [
         taco_application_implementation,

--- a/scripts/mainnet/repair_root.py
+++ b/scripts/mainnet/repair_root.py
@@ -21,9 +21,11 @@ def main():
     # Also, council must set the child application with new PolygonRoot
     # deployer.transact(taco_application.setChildApplication, polygon_root.address)
 
-    # Pending steps to be performed in Polygon
-    #     polygon_child = project.PolygonChild.at('invalid')
-    #     deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
+    # The following steps we performed manually on Polygon
+    # In [1]: polygon_child_address = "0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5"
+    # In [2]: polygon_child = project.PolygonChild.at(polygon_child_address)
+    # In [3]: polygon_root_address = "0x51825d6e893c51836dC9C0EdF3867c57CD0cACB3"
+    # In [4]: polygon_child.setFxRootTunnel(polygon_root_address, sender=...)
 
     deployments = [
         taco_application_implementation,

--- a/scripts/mainnet/repair_root.py
+++ b/scripts/mainnet/repair_root.py
@@ -20,7 +20,8 @@ def main():
         taco_application_implementation = deployer.deploy(project.TACoApplication)
         polygon_root = deployer.deploy(project.PolygonRoot)
 
-        # Council multisig must call the next function
+        # Council multisig upgrades TACoApplication with new implementation.
+        # Also, council must set the child application with new PolygonRoot
         # deployer.transact(taco_application.setChildApplication, polygon_root.address)
 
 

--- a/scripts/mainnet/repair_root.py
+++ b/scripts/mainnet/repair_root.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+from ape import project, networks
+
+from deployment.constants import ARTIFACTS_DIR, CONSTRUCTOR_PARAMS_DIR
+from deployment.params import Deployer
+from deployment.registry import read_registry
+
+VERIFY = False
+CONSTRUCTOR_PARAMS_FILEPATH = CONSTRUCTOR_PARAMS_DIR / "mainnet" / "repair-root.yml"
+
+
+def main():
+    ethereum_network = networks.ethereum.mainnet
+    polygon_network = networks.polygon.mainnet
+
+    deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)
+
+    with ethereum_network.use_provider("infura"):
+        taco_application_implementation = deployer.deploy(project.TACoApplication)
+        polygon_root = deployer.deploy(project.PolygonRoot)
+
+        # Council multisig must call the next function
+        # deployer.transact(taco_application.setChildApplication, polygon_root.address)
+
+
+    with polygon_network.use_provider("infura"):
+        polygon_child = project.PolygonChild.at('invalid')
+        deployer.transact(polygon_child.setFxRootTunnel, polygon_root.address)
+
+
+    deployments = [
+        taco_application_implementation,
+        polygon_root,
+    ]
+
+    deployer.finalize(deployments=deployments)
+

--- a/tests/application/test_operator.py
+++ b/tests/application/test_operator.py
@@ -98,7 +98,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert not taco_application.isOperatorConfirmed(operator1)
     assert taco_application.getStakingProvidersLength() == 1
     assert taco_application.stakingProviders(0) == staking_provider_3
-    assert child_application.operatorFromStakingProvider(staking_provider_3) == operator1
+    assert child_application.stakingProviderToOperator(staking_provider_3) == operator1
     assert child_application.operatorToStakingProvider(operator1) == staking_provider_3
 
     # No active stakingProviders before confirmation
@@ -109,7 +109,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     child_application.confirmOperatorAddress(operator1, sender=operator1)
     assert taco_application.stakingProviderInfo(staking_provider_3)[CONFIRMATION_SLOT]
     assert taco_application.isOperatorConfirmed(operator1)
-    assert child_application.operatorFromStakingProvider(staking_provider_3) == operator1
+    assert child_application.stakingProviderToOperator(staking_provider_3) == operator1
     assert child_application.operatorToStakingProvider(operator1) == staking_provider_3
 
     events = taco_application.OperatorBonded.from_receipt(tx)
@@ -158,7 +158,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert not taco_application.isOperatorConfirmed(operator1)
     assert taco_application.getStakingProvidersLength() == 1
     assert taco_application.stakingProviders(0) == staking_provider_3
-    assert child_application.operatorFromStakingProvider(staking_provider_3) == ZERO_ADDRESS
+    assert child_application.stakingProviderToOperator(staking_provider_3) == ZERO_ADDRESS
     assert child_application.operatorToStakingProvider(operator1) == ZERO_ADDRESS
 
     # Resetting operator removes from active list before next confirmation
@@ -185,7 +185,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert not taco_application.isOperatorConfirmed(operator2)
     assert taco_application.getStakingProvidersLength() == 1
     assert taco_application.stakingProviders(0) == staking_provider_3
-    assert child_application.operatorFromStakingProvider(staking_provider_3) == operator2
+    assert child_application.stakingProviderToOperator(staking_provider_3) == operator2
     assert child_application.operatorToStakingProvider(operator2) == staking_provider_3
 
     events = taco_application.OperatorBonded.from_receipt(tx)
@@ -206,7 +206,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert not taco_application.isOperatorConfirmed(operator1)
     assert taco_application.isOperatorConfirmed(operator2)
     assert taco_application.stakingProviderInfo(staking_provider_3)[CONFIRMATION_SLOT]
-    assert child_application.operatorFromStakingProvider(staking_provider_3) == operator2
+    assert child_application.stakingProviderToOperator(staking_provider_3) == operator2
     assert child_application.operatorToStakingProvider(operator2) == staking_provider_3
 
     # Another staking provider can bond a free operator
@@ -220,7 +220,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert taco_application.getStakingProvidersLength() == 2
     assert taco_application.stakingProviders(1) == staking_provider_4
     assert taco_application.authorizedOverall() == min_authorization
-    assert child_application.operatorFromStakingProvider(staking_provider_4) == operator1
+    assert child_application.stakingProviderToOperator(staking_provider_4) == operator1
     assert child_application.operatorToStakingProvider(operator1) == staking_provider_4
 
     events = taco_application.OperatorBonded.from_receipt(tx)
@@ -244,7 +244,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert taco_application.isOperatorConfirmed(operator1)
     assert taco_application.stakingProviderInfo(staking_provider_4)[CONFIRMATION_SLOT]
     assert taco_application.authorizedOverall() == 2 * min_authorization
-    assert child_application.operatorFromStakingProvider(staking_provider_4) == operator1
+    assert child_application.stakingProviderToOperator(staking_provider_4) == operator1
     assert child_application.operatorToStakingProvider(operator1) == staking_provider_4
 
     chain.pending_timestamp += min_operator_seconds
@@ -259,7 +259,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert taco_application.getStakingProvidersLength() == 2
     assert taco_application.stakingProviders(1) == staking_provider_4
     assert taco_application.authorizedOverall() == min_authorization
-    assert child_application.operatorFromStakingProvider(staking_provider_4) == operator3
+    assert child_application.stakingProviderToOperator(staking_provider_4) == operator3
     assert child_application.operatorToStakingProvider(operator1) == ZERO_ADDRESS
     assert child_application.operatorToStakingProvider(operator3) == staking_provider_4
 
@@ -316,7 +316,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
         staking_provider_1, min_authorization, min_authorization - 1, sender=creator
     )
     child_application.confirmOperatorAddress(staking_provider_1, sender=staking_provider_1)
-    assert child_application.operatorFromStakingProvider(staking_provider_1) == staking_provider_1
+    assert child_application.stakingProviderToOperator(staking_provider_1) == staking_provider_1
     assert child_application.operatorToStakingProvider(staking_provider_1) == staking_provider_1
 
     # If stake will be less than minimum then provider is not active


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
`PolygonChild`: `renounceOwnership` happens only when all parameters set
`TACoApplication`: manual sync state, with normal behavior of bridge - will do mostly nothing

**Notes for reviewers:**
I considered adding similar method (manual) to child app. But opposite sync (Polygon -> Mainnet) is trickier then direct one (Mainnet -> Polygon) and there is more things to consider. And it could be useful only when opposite sync will be implemented anyway (bot or dashboard)
