### PR TITLE
Fix refund calculation bug in BetaProgramInitiator (part 2)

### DIFF
--- a/contracts/contracts/coordination/FlatRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlatRateFeeModel.sol
@@ -30,7 +30,7 @@ contract FlatRateFeeModel is IFeeModel {
     }
 
     // TODO: Validate if this is enough to remove griefing attacks
-    function feeDeduction(uint256 pending, uint256) public pure returns (uint256) {
+    function feeDeduction(uint256, uint256) public pure returns (uint256) {
         return 0;
     }
 }

--- a/contracts/contracts/coordination/FlatRateFeeModel.sol
+++ b/contracts/contracts/coordination/FlatRateFeeModel.sol
@@ -31,6 +31,6 @@ contract FlatRateFeeModel is IFeeModel {
 
     // TODO: Validate if this is enough to remove griefing attacks
     function feeDeduction(uint256 pending, uint256) public pure returns (uint256) {
-        return pending;
+        return 0;
     }
 }

--- a/deployment/artifacts/mainnet.json
+++ b/deployment/artifacts/mainnet.json
@@ -1541,7 +1541,7 @@
     },
     "137": {
         "BetaProgramInitiator": {
-            "address": "0x2A8eA9760CB41a36f8320B8020173D3CA0495FC8",
+            "address": "0x7CEbC88351061b2721865f01d2aCEc4c3eC92E8d",
             "abi": [
                 {
                     "type": "constructor",
@@ -1905,8 +1905,8 @@
                     ]
                 }
             ],
-            "tx_hash": "0xd20ad04b6b39c7913e313c75c566170bd9891649cf2bae0706bb11ac23404626",
-            "block_number": 51972892,
+            "tx_hash": "0xca501b1153acf6d47a2def2413fc5c72302f6d87c050f4e859eacc888e3fc492",
+            "block_number": 52701776,
             "deployer": "0x1591165F1BF8B73de7053A6BE6f239BC15076879"
         },
         "Coordinator": {

--- a/deployment/constructor_params/mainnet/redeploy-coordinator.yml
+++ b/deployment/constructor_params/mainnet/redeploy-coordinator.yml
@@ -1,0 +1,26 @@
+deployment:
+  name: redeploy-coordinator
+  chain_id: 137  # Polygon Mainnet
+
+artifacts:
+  dir: ./deployment/artifacts/
+  filename: redeploy-coordinator.json
+
+constants:
+  # See deployment/artifacts/mainnet.json
+  TACO_CHILD_APPLICATION: "0xFa07aaB78062Fac4C36995bF28F6D677667973F5"
+
+  # DAI Token on Polygon PoS - References:
+  # - https://polygonscan.com/token/0x8f3cf7ad23cd3cadbd9735aff958023239c6a063
+  # - https://github.com/search?q=0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063&type=code
+  DAI_ON_POLYGON: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+
+  # TACO specific constants:
+  PRIVATE_BETA_FEE_RATE: 4050925925925  # $0.35 per day, expressed in DAI units per seconds (in Python: 35*10**16 // 86400)
+
+contracts:
+  - Coordinator:
+      constructor:
+        _application: $TACO_CHILD_APPLICATION
+        _currency: $DAI_ON_POLYGON
+        _feeRatePerSecond: $PRIVATE_BETA_FEE_RATE

--- a/scripts/mainnet/redeploy_coordinator.py
+++ b/scripts/mainnet/redeploy_coordinator.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+from ape import project
+
+from deployment.constants import CONSTRUCTOR_PARAMS_DIR
+from deployment.params import Deployer
+
+VERIFY = False
+CONSTRUCTOR_PARAMS_FILEPATH = CONSTRUCTOR_PARAMS_DIR / "mainnet" / "redeploy-coordinator.yml"
+
+
+def main():
+
+    deployer = Deployer.from_yaml(filepath=CONSTRUCTOR_PARAMS_FILEPATH, verify=VERIFY)
+
+    coordinator_implementation = deployer.deploy(project.Coordinator)
+
+    deployments = [
+        coordinator_implementation,
+    ]
+
+    deployer.finalize(deployments=deployments)
+


### PR DESCRIPTION
(Continuation of https://github.com/nucypher/nucypher-contracts/pull/228)

As part of a longer-term solution that doesn't involve the Threshold Council and/or Treasury Guild managing refunds manually, this PR sets the refunds to be 100% so that the complete fee goes back to the BetaProgramInitiator, and then to the original adopter. 

**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
