### PR TITLE
Optimized Participant Views

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -41,4 +41,4 @@ ethereum:
 
 test:
   mnemonic: test test test test test test test test test test test junk
-  number_of_accounts: 10
+  number_of_accounts: 40

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -479,6 +479,32 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return (participant, index);
     }
 
+    function getParticipants(
+        uint32 ritualId,
+        uint256 _startIndex,
+        uint256 _maxParticipants,
+        bool _includeTranscript
+    ) external view returns (Participant[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        uint256 endIndex = ritual.participant.length;
+        require(_startIndex < endIndex, "Wrong start index");
+        if (_maxParticipants != 0 && _startIndex + _maxParticipants < endIndex) {
+            endIndex = _startIndex + _maxParticipants;
+        }
+        Participant[] memory ritualParticipants = new Participant[](endIndex - _startIndex);
+
+        uint256 resultIndex = 0;
+        for (uint256 i = _startIndex; i < endIndex; i++) {
+            Participant memory ritualParticipant = ritual.participant[i];
+            if (!_includeTranscript) {
+                ritualParticipant.transcript = "";
+            }
+            ritualParticipants[resultIndex++] = ritualParticipant;
+        }
+
+        return ritualParticipants;
+    }
+
     function getProviders(uint32 ritualId) external view returns (address[] memory) {
         Ritual storage ritual = rituals[ritualId];
         address[] memory providers = new address[](ritual.participant.length);

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -465,13 +465,17 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return (found, index);
     }
 
-    function getProviders(uint32 ritualId) external view returns (address[] memory) {
+    function getAllParticipants(uint32 ritualId) external view returns (Participant[] memory) {
         Ritual storage ritual = rituals[ritualId];
-        address[] memory addresses = new address[](ritual.participant.length);
+        Participant[] memory participants = new Participant[](ritual.dkgSize);
         for (uint256 i = 0; i < ritual.participant.length; i++) {
-            addresses[i] = ritual.participant[i].provider;
+            Participant memory participant;
+            participant.provider = ritual.participant[i].provider;
+            participant.aggregated = ritual.participant[i].aggregated;
+            participant.decryptionRequestStaticKey = ritual.participant[i].decryptionRequestStaticKey;
+            participants[i] = participant;
         }
-        return addresses;
+        return participants;
     }
 
     function isEncryptionAuthorized(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -429,17 +429,24 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         Ritual storage ritual,
         address provider
     ) internal view returns (bool, uint256, Participant storage participant) {
+        uint256 length = ritual.participant.length;
+        if (length == 0) {
+            return (false, 0, SENTINEL_PARTICIPANT);
+        }
         uint256 low = 0;
-        uint256 high = ritual.participant.length - 1;
+        uint256 high = length - 1;
         while (low <= high) {
-            uint256 mid = low + (high - low) / 2;
+            uint256 mid = (low + high) / 2;
             Participant storage participant = ritual.participant[mid];
-            if (participant.provider < provider) {
-                low = mid + 1;
-            } else if (participant.provider > provider) {
-                high = mid - 1;
-            } else {
+            if (participant.provider == provider) {
                 return (true, mid, participant);
+            } else if (participant.provider < provider) {
+                low = mid + 1;
+            } else if (high == 0) {
+                // prevent underflow of unsigned int
+                return (false, 0, SENTINEL_PARTICIPANT);
+            } else {
+                high = mid - 1;
             }
         }
         return (false, 0, sentinelParticipant);

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -431,7 +431,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     ) internal view returns (bool, uint256, Participant storage participant) {
         uint256 length = ritual.participant.length;
         if (length == 0) {
-            return (false, 0, SENTINEL_PARTICIPANT);
+            return (false, 0, sentinelParticipant);
         }
         uint256 low = 0;
         uint256 high = length - 1;
@@ -444,7 +444,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
                 low = mid + 1;
             } else if (high == 0) {
                 // prevent underflow of unsigned int
-                return (false, 0, SENTINEL_PARTICIPANT);
+                return (false, 0, sentinelParticipant);
             } else {
                 high = mid - 1;
             }
@@ -469,7 +469,10 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         bool transcript
     ) public view returns (Participant memory, uint256) {
         Ritual storage ritual = rituals[ritualId];
-        (bool found, uint256 index, Participant memory participant) = findParticipant(ritual, provider);
+        (bool found, uint256 index, Participant memory participant) = findParticipant(
+            ritual,
+            provider
+        );
         if (!found) {
             revert("Participant not part of ritual");
         }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -420,7 +420,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return ritual.publicKey;
     }
 
-    function _getParticipant(
+    function findParticipant(
         Ritual storage ritual,
         address provider
     ) internal view returns (bool, uint256, Participant storage participant) {
@@ -444,7 +444,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         Ritual storage ritual,
         address provider
     ) internal view returns (Participant storage) {
-        (bool found,, Participant storage participant) = _getParticipant(ritual, provider);
+        (bool found,, Participant storage participant) = findParticipant(ritual, provider);
         require(found, "Participant not found");
         return participant;
     }
@@ -465,7 +465,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
 
     function isParticipant(uint32 ritualId, address provider) external view returns (bool, uint256) {
         Ritual storage ritual = rituals[ritualId];
-        (bool found, uint256 index,) = _getParticipant(ritual, provider);
+        (bool found, uint256 index,) = findParticipant(ritual, provider);
         return (found, index);
     }
 

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -241,6 +241,11 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return rituals.length;
     }
 
+    function getParticipants(uint32 ritualId) external view returns (Participant[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        return ritual.participant;
+    }
+
     function getThresholdForRitualSize(uint16 size) public pure returns (uint16) {
         return 1 + size / 2;
         // Alternatively: 1 + 2*size/3 (for >66.6%) or 1 + 3*size/5 (for >60%)

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -482,8 +482,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         uint32 ritualId,
         address provider
     ) external view returns (bool) {
-        Ritual storage ritual = rituals[ritualId];
-        try getParticipantFromProvider(ritual, provider) {
+        try getParticipantFromProvider(ritualId, provider) {
             return true;
         } catch {
             return false;

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -484,22 +484,6 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return ritual.participant;
     }
 
-    function getParticipants(
-        uint32 ritualId,
-        uint256 start,
-        uint256 end
-    ) external view returns (Participant[] memory) {
-        Ritual storage ritual = rituals[ritualId];
-        require(start < ritual.participant.length, "Start index out of bounds");
-        require(end <= ritual.participant.length, "End index out of bounds");
-        require(start < end, "Start index must be less than end index");
-        Participant[] memory participants = new Participant[](end - start);
-        for (uint256 i = start; i < end; i++) {
-            participants[i - start] = ritual.participant[i];
-        }
-        return participants;
-    }
-
     function getParticipantProviders(uint32 ritualId) external view returns (address[] memory) {
         Ritual storage ritual = rituals[ritualId];
         address[] memory addresses = new address[](ritual.participant.length);

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -451,11 +451,15 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
 
     function getParticipant(
         uint32 ritualId,
-        address provider
+        address provider,
+        bool transcripts
     ) external view returns (Participant memory, uint256) {
         Ritual storage ritual = rituals[ritualId];
-        (bool found, uint256 index, Participant storage participant) = _getParticipant(ritual, provider);
+        (bool found, uint256 index, Participant memory participant) = _getParticipant(ritual, provider);
         require(found, "Participant not found");
+        if (!transcripts) {
+            participant.transcript = '';
+        }
         return (participant, index);
     }
 
@@ -463,19 +467,6 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         Ritual storage ritual = rituals[ritualId];
         (bool found, uint256 index,) = _getParticipant(ritual, provider);
         return (found, index);
-    }
-
-    function getAllParticipants(uint32 ritualId) external view returns (Participant[] memory) {
-        Ritual storage ritual = rituals[ritualId];
-        Participant[] memory participants = new Participant[](ritual.dkgSize);
-        for (uint256 i = 0; i < ritual.participant.length; i++) {
-            Participant memory participant;
-            participant.provider = ritual.participant[i].provider;
-            participant.aggregated = ritual.participant[i].aggregated;
-            participant.decryptionRequestStaticKey = ritual.participant[i].decryptionRequestStaticKey;
-            participants[i] = participant;
-        }
-        return participants;
     }
 
     function isEncryptionAuthorized(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -310,7 +310,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         );
 
         address provider = application.operatorToStakingProvider(msg.sender);
-        Participant storage participant = getParticipantFromProvider(ritual, provider);
+        (Participant storage participant, uint256 _index) = getParticipantFromProvider(ritual, provider);
 
         require(application.authorizedStake(provider) > 0, "Not enough authorization");
         require(participant.transcript.length == 0, "Node already posted transcript");
@@ -349,7 +349,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         );
 
         address provider = application.operatorToStakingProvider(msg.sender);
-        Participant storage participant = getParticipantFromProvider(ritual, provider);
+        (Participant storage participant, uint256 _index) = getParticipantFromProvider(ritual, provider);
         require(application.authorizedStake(provider) > 0, "Not enough authorization");
 
         require(!participant.aggregated, "Node already posted aggregation");

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -457,7 +457,9 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         address provider
     ) internal view returns (Participant storage) {
         (bool found, , Participant storage participant) = findParticipant(ritual, provider);
-        require(found, "Participant not found");
+        if (!found) {
+            revert("Participant not part of ritual");
+        }
         return participant;
     }
 
@@ -467,11 +469,10 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         bool transcript
     ) public view returns (Participant memory, uint256) {
         Ritual storage ritual = rituals[ritualId];
-        (bool found, uint256 index, Participant memory participant) = findParticipant(
-            ritual,
-            provider
-        );
-        require(found, "Participant not found");
+        (bool found, uint256 index, Participant memory participant) = findParticipant(ritual, provider);
+        if (!found) {
+            revert("Participant not part of ritual");
+        }
         if (!transcript) {
             participant.transcript = "";
         }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -240,32 +240,6 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return rituals.length;
     }
 
-    function getParticipants(uint32 ritualId) external view returns (Participant[] memory) {
-        Ritual storage ritual = rituals[ritualId];
-        return ritual.participant;
-    }
-
-    function getParticipants(uint32 ritualId, uint256 start, uint256 end) external view returns (Participant[] memory) {
-        Ritual storage ritual = rituals[ritualId];
-        require(start < ritual.participant.length, "Start index out of bounds");
-        require(end <= ritual.participant.length, "End index out of bounds");
-        require(start < end, "Start index must be less than end index");
-        Participant[] memory participants = new Participant[](end - start);
-        for (uint256 i = start; i < end; i++) {
-            participants[i - start] = ritual.participant[i];
-        }
-        return participants;
-    }
-
-    function getParticipantProviders(uint32 ritualId) external view returns (address[] memory) {
-        Ritual storage ritual = rituals[ritualId];
-        address[] memory addresses = new address[](ritual.participant.length);
-        for (uint256 i = 0; i < ritual.participant.length; i++) {
-            addresses[i] = ritual.participant[i].provider;
-        }
-        return addresses;
-    }
-
     function getThresholdForRitualSize(uint16 size) public pure returns (uint16) {
         return 1 + size / 2;
         // Alternatively: 1 + 2*size/3 (for >66.6%) or 1 + 3*size/5 (for >60%)
@@ -470,6 +444,32 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         address provider
     ) external view returns (Participant memory, uint256) {
         return getParticipantFromProvider(rituals[ritualId], provider);
+    }
+
+    function getParticipants(uint32 ritualId) external view returns (Participant[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        return ritual.participant;
+    }
+
+    function getParticipants(uint32 ritualId, uint256 start, uint256 end) external view returns (Participant[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        require(start < ritual.participant.length, "Start index out of bounds");
+        require(end <= ritual.participant.length, "End index out of bounds");
+        require(start < end, "Start index must be less than end index");
+        Participant[] memory participants = new Participant[](end - start);
+        for (uint256 i = start; i < end; i++) {
+            participants[i - start] = ritual.participant[i];
+        }
+        return participants;
+    }
+
+    function getParticipantProviders(uint32 ritualId) external view returns (address[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        address[] memory addresses = new address[](ritual.participant.length);
+        for (uint256 i = 0; i < ritual.participant.length; i++) {
+            addresses[i] = ritual.participant[i].provider;
+        }
+        return addresses;
     }
 
     function isEncryptionAuthorized(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -487,6 +487,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     ) external view returns (Participant[] memory) {
         Ritual storage ritual = rituals[ritualId];
         uint256 endIndex = ritual.participant.length;
+        require(_startIndex >= 0, "Invalid start index");
         require(_startIndex < endIndex, "Wrong start index");
         if (_maxParticipants != 0 && _startIndex + _maxParticipants < endIndex) {
             endIndex = _startIndex + _maxParticipants;

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -245,6 +245,18 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return ritual.participant;
     }
 
+    function getParticipants(uint32 ritualId, uint256 start, uint256 end) external view returns (Participant[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        require(start < ritual.participant.length, "Start index out of bounds");
+        require(end <= ritual.participant.length, "End index out of bounds");
+        require(start < end, "Start index must be less than end index");
+        Participant[] memory participants = new Participant[](end - start);
+        for (uint256 i = start; i < end; i++) {
+            participants[i - start] = ritual.participant[i];
+        }
+        return participants;
+    }
+
     function getThresholdForRitualSize(uint16 size) public pure returns (uint16) {
         return 1 + size / 2;
         // Alternatively: 1 + 2*size/3 (for >66.6%) or 1 + 3*size/5 (for >60%)

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -465,7 +465,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         uint32 ritualId,
         address provider,
         bool transcript
-    ) public view returns (Participant memory, uint256) {
+    ) external view returns (Participant memory, uint256) {
         Ritual storage ritual = rituals[ritualId];
         (bool found, uint256 index, Participant memory participant) = findParticipant(
             ritual,

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -104,7 +104,8 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     IReimbursementPool internal reimbursementPool;
     mapping(address => ParticipantKey[]) internal participantKeysHistory;
     mapping(bytes32 => uint32) internal ritualPublicKeyRegistry;
-    Participant internal sentinelParticipant;
+    mapping(uint256 => Participant) internal sentinelParticipants;
+    uint256 internal sentinelIndex = 0;
 
     constructor(
         ITACoChildApplication _application,
@@ -431,7 +432,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     ) internal view returns (bool, uint256, Participant storage participant) {
         uint256 length = ritual.participant.length;
         if (length == 0) {
-            return (false, 0, sentinelParticipant);
+            return (false, 0, sentinelParticipants[sentinelIndex]);
         }
         uint256 low = 0;
         uint256 high = length - 1;
@@ -445,12 +446,12 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             } else {
                 if (mid == 0) {
                     // prevent underflow of unsigned int
-                    return (false, 0, sentinelParticipant);
+                    break;
                 }
                 high = mid - 1;
             }
         }
-        return (false, 0, sentinelParticipant);
+        return (false, 0, sentinelParticipants[sentinelIndex]);
     }
 
     function getParticipant(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -485,6 +485,15 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return (participant, index);
     }
 
+    function getParticipantFromProvider(
+        uint32 ritualId,
+        address provider
+    ) external view returns (Participant memory) {
+        Ritual storage ritual = rituals[ritualId];
+        Participant memory participant = getParticipant(ritual, provider);
+        return participant;
+    }
+
     function getParticipants(
         uint32 ritualId,
         uint256 startIndex,

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -457,9 +457,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         address provider
     ) internal view returns (Participant storage) {
         (bool found, , Participant storage participant) = findParticipant(ritual, provider);
-        if (!found) {
-            revert("Participant not part of ritual");
-        }
+        require(found, "Participant not part of ritual");
         return participant;
     }
 
@@ -473,9 +471,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             ritual,
             provider
         );
-        if (!found) {
-            revert("Participant not part of ritual");
-        }
+        require(found, "Participant not part of ritual");
         if (!transcript) {
             participant.transcript = "";
         }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -60,6 +60,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         bool aggregated;
         bytes transcript;
         bytes decryptionRequestStaticKey;
+        // Note: Adjust __postSentinelGap size if this struct's size changes
     }
 
     struct Ritual {
@@ -104,8 +105,12 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     IReimbursementPool internal reimbursementPool;
     mapping(address => ParticipantKey[]) internal participantKeysHistory;
     mapping(bytes32 => uint32) internal ritualPublicKeyRegistry;
-    mapping(uint256 => Participant) internal sentinelParticipants;
-    uint256 internal sentinelIndex = 0;
+    // Note: Adjust the __preSentinelGap size if more contract variables are added
+
+    // Storage area for sentinel values
+    uint256[20] internal __preSentinelGap;
+    Participant internal __sentinelParticipant;
+    uint256[20] internal __postSentinelGap;
 
     constructor(
         ITACoChildApplication _application,
@@ -432,7 +437,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     ) internal view returns (bool, uint256, Participant storage participant) {
         uint256 length = ritual.participant.length;
         if (length == 0) {
-            return (false, 0, sentinelParticipants[sentinelIndex]);
+            return (false, 0, __sentinelParticipant);
         }
         uint256 low = 0;
         uint256 high = length - 1;
@@ -451,7 +456,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
                 high = mid - 1;
             }
         }
-        return (false, 0, sentinelParticipants[sentinelIndex]);
+        return (false, 0, __sentinelParticipant);
     }
 
     function getParticipant(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -448,13 +448,18 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     function getParticipantFromProvider(
         Ritual storage ritual,
         address provider
-    ) internal view returns (Participant storage) {
-        uint256 length = ritual.participant.length;
-        // TODO: Improve with binary search
-        for (uint256 i = 0; i < length; i++) {
-            Participant storage participant = ritual.participant[i];
-            if (participant.provider == provider) {
-                return participant;
+    ) internal view returns (Participant storage, uint256) {
+        uint256 low = 0;
+        uint256 high = ritual.participant.length - 1;
+        while (low <= high) {
+            uint256 mid = low + (high - low) / 2;
+            Participant storage participant = ritual.participant[mid];
+            if (participant.provider < provider) {
+                low = mid + 1;
+            } else if (participant.provider > provider) {
+                high = mid - 1;
+            } else {
+                return (participant, mid); // Participant found
             }
         }
         revert("Participant not part of ritual");
@@ -463,7 +468,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
     function getParticipantFromProvider(
         uint32 ritualId,
         address provider
-    ) external view returns (Participant memory) {
+    ) external view returns (Participant memory, uint256) {
         return getParticipantFromProvider(rituals[ritualId], provider);
     }
 

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -442,10 +442,11 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
                 return (true, mid, middleParticipant);
             } else if (middleParticipant.provider < provider) {
                 low = mid + 1;
-            } else if (high == 0) {
-                // prevent underflow of unsigned int
-                return (false, 0, sentinelParticipant);
             } else {
+                if (mid == 0) {
+                    // prevent underflow of unsigned int
+                    return (false, 0, sentinelParticipant);
+                }
                 high = mid - 1;
             }
         }

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -446,12 +446,18 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return getParticipantFromProvider(rituals[ritualId], provider);
     }
 
-    function getParticipants(uint32 ritualId) external view returns (Participant[] memory) {
+    function getParticipants(
+        uint32 ritualId
+    ) external view returns (Participant[] memory) {
         Ritual storage ritual = rituals[ritualId];
         return ritual.participant;
     }
 
-    function getParticipants(uint32 ritualId, uint256 start, uint256 end) external view returns (Participant[] memory) {
+    function getParticipants(
+        uint32 ritualId,
+        uint256 start,
+        uint256 end
+    ) external view returns (Participant[] memory) {
         Ritual storage ritual = rituals[ritualId];
         require(start < ritual.participant.length, "Start index out of bounds");
         require(end <= ritual.participant.length, "End index out of bounds");
@@ -470,6 +476,18 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             addresses[i] = ritual.participant[i].provider;
         }
         return addresses;
+    }
+
+    function isProviderParticipating(
+        uint32 ritualId,
+        address provider
+    ) external view returns (bool) {
+        Ritual storage ritual = rituals[ritualId];
+        try getParticipantFromProvider(ritual, provider) {
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     function isEncryptionAuthorized(

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -166,7 +166,7 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
             //   - No public key
             //   - All transcripts and all aggregations
             //   - Still within the deadline
-            assert(false);
+            revert("Ambiguous ritual state");
         }
     }
 

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -437,10 +437,10 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         uint256 high = length - 1;
         while (low <= high) {
             uint256 mid = (low + high) / 2;
-            Participant storage participant = ritual.participant[mid];
-            if (participant.provider == provider) {
-                return (true, mid, participant);
-            } else if (participant.provider < provider) {
+            Participant storage middleParticipant = ritual.participant[mid];
+            if (middleParticipant.provider == provider) {
+                return (true, mid, middleParticipant);
+            } else if (middleParticipant.provider < provider) {
                 low = mid + 1;
             } else if (high == 0) {
                 // prevent underflow of unsigned int

--- a/contracts/contracts/coordination/Coordinator.sol
+++ b/contracts/contracts/coordination/Coordinator.sol
@@ -257,6 +257,15 @@ contract Coordinator is Initializable, AccessControlDefaultAdminRulesUpgradeable
         return participants;
     }
 
+    function getParticipantProviders(uint32 ritualId) external view returns (address[] memory) {
+        Ritual storage ritual = rituals[ritualId];
+        address[] memory addresses = new address[](ritual.participant.length);
+        for (uint256 i = 0; i < ritual.participant.length; i++) {
+            addresses[i] = ritual.participant[i].provider;
+        }
+        return addresses;
+    }
+
     function getThresholdForRitualSize(uint16 size) public pure returns (uint16) {
         return 1 + size / 2;
         // Alternatively: 1 + 2*size/3 (for >66.6%) or 1 + 3*size/5 (for >60%)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -390,6 +390,17 @@ def test_get_participant(nodes, coordinator, initiator, erc20, global_allow_list
         assert p.aggregated is False
         assert p.transcript == transcript
 
+        p, index = coordinator.getParticipant(0, node.address, False)
+        assert index == i
+        assert p.provider == node.address
+        assert p.aggregated is False
+        assert not p.transcript
+
+        p = coordinator.getParticipantFromProvider(0, node.address)
+        assert p.provider == node.address
+        assert p.aggregated is False
+        assert p.transcript == transcript
+
     # can't find non-participants
     for i in range(5):
         while True:
@@ -398,6 +409,12 @@ def test_get_participant(nodes, coordinator, initiator, erc20, global_allow_list
                 break
         with ape.reverts("Participant not part of ritual"):
             coordinator.getParticipant(0, new_account.address, True)
+
+        with ape.reverts("Participant not part of ritual"):
+            coordinator.getParticipant(0, new_account.address, False)
+
+        with ape.reverts("Participant not part of ritual"):
+            coordinator.getParticipantFromProvider(0, new_account.address)
 
 
 def test_post_aggregation(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,7 @@ from eth_account.messages import encode_defunct
 from web3 import Web3
 
 TIMEOUT = 1000
-MAX_DKG_SIZE = 4
+MAX_DKG_SIZE = 30
 FEE_RATE = 42
 ERC20_SUPPLY = 10**24
 DURATION = 48 * 60 * 60
@@ -349,7 +349,12 @@ def test_get_participants(coordinator, nodes, initiator, erc20, global_allow_lis
         assert not participant.transcript
 
     # n at a time
-    for n_at_a_time in range(1, len(nodes)):
+    for n_at_a_time in range(2, len(nodes) // 2):
+        if len(nodes) % n_at_a_time == 1:
+            # TODO ugly; decoding issues with web3py/ape w.r.t
+            #  struct array of size 1 not being returned as an array of 1 tuple
+            #  but rather an array of tuple elements - more investigation needed
+            continue
         index = 0
         while index < len(nodes):
             participants_n_at_a_time = coordinator.getParticipants(0, index, n_at_a_time, True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -348,10 +348,9 @@ def test_get_participants(coordinator, nodes, initiator, erc20, global_allow_lis
         assert not participant.transcript
 
     # n at a time
-    for n_at_a_time in [2]:
+    for n_at_a_time in range(1, len(nodes)):
         index = 0
         while index < len(nodes):
-            print(f">>>> Start Index {index}, End Index {index+n_at_a_time}")
             participants_n_at_a_time = coordinator.getParticipants(0, index, index+n_at_a_time, True)
             assert len(participants_n_at_a_time) <= n_at_a_time
             for i, participant in enumerate(participants_n_at_a_time):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -392,14 +392,12 @@ def test_get_participant(nodes, coordinator, initiator, erc20, global_allow_list
 
     # find actual participants
     for i, node in enumerate(nodes):
-        p, index = coordinator.getParticipant(0, node.address, True)
-        assert index == i
+        p = coordinator.getParticipant(0, node.address, True)
         assert p.provider == node.address
         assert p.aggregated is False
         assert p.transcript == transcript
 
-        p, index = coordinator.getParticipant(0, node.address, False)
-        assert index == i
+        p = coordinator.getParticipant(0, node.address, False)
         assert p.provider == node.address
         assert p.aggregated is False
         assert not p.transcript

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -352,14 +352,14 @@ def test_get_participants(coordinator, nodes, initiator, erc20, global_allow_lis
     for n_at_a_time in range(1, len(nodes)):
         index = 0
         while index < len(nodes):
-            participants_n_at_a_time = coordinator.getParticipants(0, index, index+n_at_a_time, True)
+            participants_n_at_a_time = coordinator.getParticipants(0, index, n_at_a_time, True)
             assert len(participants_n_at_a_time) <= n_at_a_time
             for i, participant in enumerate(participants_n_at_a_time):
                 assert participant.provider == nodes[index+i].address
                 assert participant.aggregated is False
                 assert participant.transcript == transcript
 
-            index += n_at_a_time
+            index += len(participants_n_at_a_time)
 
         assert index == len(nodes)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,7 @@ from eth_account.messages import encode_defunct
 from web3 import Web3
 
 TIMEOUT = 1000
-MAX_DKG_SIZE = 30
+MAX_DKG_SIZE = 31
 FEE_RATE = 42
 ERC20_SUPPLY = 10**24
 DURATION = 48 * 60 * 60
@@ -347,6 +347,14 @@ def test_get_participants(coordinator, nodes, initiator, erc20, global_allow_lis
         assert participant.provider == nodes[index].address
         assert participant.aggregated is False
         assert not participant.transcript
+
+    # max is 0 which means get all
+    participants = coordinator.getParticipants(0, 0, 0, True)
+    assert len(participants) == len(nodes)
+    for index, participant in enumerate(participants):
+        assert participant.provider == nodes[index].address
+        assert participant.aggregated is False
+        assert participant.transcript == transcript
 
     # n at a time
     for n_at_a_time in range(2, len(nodes) // 2):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -387,8 +387,10 @@ def test_get_participant(nodes, coordinator, initiator, erc20, global_allow_list
 
     # can't find non-participants
     for i in range(5):
-        new_account = Account.create()
-        assert new_account.address not in nodes
+        while True:
+            new_account = Account.create()
+            if new_account.address not in nodes:
+                break
         with ape.reverts("Participant not part of ritual"):
             coordinator.getParticipant(0, new_account.address, True)
 


### PR DESCRIPTION
- Paginated `getParticipants`view with optional transcripts
- `isParticipant` checks if a staking provider address belong to a ritual's participants
- Optimize internal participant lookups with binary search

##### Notes
Requires downstream changes https://github.com/nucypher/nucypher/pull/3419