### PR TITLE
Fix ABI ordering for lynx registry file - was incorrect due to my faulty merging after deployment.

### DIFF
--- a/deployment/artifacts/lynx.json
+++ b/deployment/artifacts/lynx.json
@@ -1138,63 +1138,7 @@
                         }
                     ]
                 },
-              {
-                "type": "function",
-                "name": "getParticipants",
-                "stateMutability": "view",
-                "inputs": [
-                  {
-                    "internalType": "uint32",
-                    "name": "ritualId",
-                    "type": "uint32"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "startIndex",
-                    "type": "uint256"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "maxParticipants",
-                    "type": "uint256"
-                  },
-                  {
-                    "internalType": "bool",
-                    "name": "includeTranscript",
-                    "type": "bool"
-                  }
-                ],
-                "outputs": [
-                  {
-                    "components": [
-                      {
-                        "internalType": "address",
-                        "name": "provider",
-                        "type": "address"
-                      },
-                      {
-                        "internalType": "bool",
-                        "name": "aggregated",
-                        "type": "bool"
-                      },
-                      {
-                        "internalType": "bytes",
-                        "name": "transcript",
-                        "type": "bytes"
-                      },
-                      {
-                        "internalType": "bytes",
-                        "name": "decryptionRequestStaticKey",
-                        "type": "bytes"
-                      }
-                    ],
-                    "internalType": "struct Coordinator.Participant[]",
-                    "name": "",
-                    "type": "tuple[]"
-                  }
-                ]
-              },
-              {
+                {
                     "type": "function",
                     "name": "getParticipantFromProvider",
                     "stateMutability": "view",
@@ -1249,6 +1193,62 @@
                             "name": "ritualId",
                             "type": "uint32",
                             "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple[]",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipants",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "maxParticipants",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "includeTranscript",
+                            "type": "bool",
+                            "internalType": "bool"
                         }
                     ],
                     "outputs": [


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Fixes lynx registry after latest deployment - #234 . The ordering was incorrect after #235 .

Properly merge the deployment registry and latest lynx into a separate temporary file first then replaced lynx.json. 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
