### PR TITLE
Adds deauthorizing amount to bridge synchronization

### DIFF
--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -150,6 +150,8 @@ contract TACoApplication is
     event ManualChildSynchronizationSent(
         address indexed stakingProvider,
         uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization,
         address operator
     );
 
@@ -655,10 +657,18 @@ contract TACoApplication is
     }
 
     /**
-     * @notice Get all tokens delegated to the staking provider
+     * @notice Get eligible stake delegated to the staking provider
      */
-    function getEligibleAmount(StakingProviderInfo storage _info) internal view returns (uint96) {
-        return _info.authorized - _info.deauthorizing;
+    function eligibleStake(
+        address _stakingProvider,
+        uint256 _endDate
+    ) public view returns (uint96) {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        uint96 eligibleAmount = info.endDeauthorization == 0 || info.endDeauthorization >= _endDate
+            ? info.authorized
+            : info.authorized - info.deauthorizing;
+
+        return eligibleAmount;
     }
 
     /**
@@ -690,6 +700,7 @@ contract TACoApplication is
      * @notice Get the value of authorized tokens for active providers as well as providers and their authorized tokens
      * @param _startIndex Start index for looking in providers array
      * @param _maxStakingProviders Max providers for looking, if set 0 then all will be used
+     * @param _cohortDuration Duration during which staking provider should be active. 0 means no end date
      * @return allAuthorizedTokens Sum of authorized tokens for active providers
      * @return activeStakingProviders Array of providers and their authorized tokens.
      * Providers addresses stored together with amounts as bytes32
@@ -698,7 +709,8 @@ contract TACoApplication is
      */
     function getActiveStakingProviders(
         uint256 _startIndex,
-        uint256 _maxStakingProviders
+        uint256 _maxStakingProviders,
+        uint32 _cohortDuration
     ) external view returns (uint256 allAuthorizedTokens, bytes32[] memory activeStakingProviders) {
         uint256 endIndex = stakingProviders.length;
         require(_startIndex < endIndex, "Wrong start index");
@@ -707,12 +719,15 @@ contract TACoApplication is
         }
         activeStakingProviders = new bytes32[](endIndex - _startIndex);
         allAuthorizedTokens = 0;
+        uint256 endDate = _cohortDuration == 0
+            ? type(uint256).max
+            : block.timestamp + _cohortDuration;
 
         uint256 resultIndex = 0;
         for (uint256 i = _startIndex; i < endIndex; i++) {
             address stakingProvider = stakingProviders[i];
             StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
-            uint256 eligibleAmount = getEligibleAmount(info);
+            uint256 eligibleAmount = eligibleStake(stakingProvider, endDate);
             if (eligibleAmount < minimumAuthorization || !info.operatorConfirmed) {
                 continue;
             }
@@ -873,9 +888,12 @@ contract TACoApplication is
         address _stakingProvider,
         StakingProviderInfo storage _info
     ) internal {
-        // TODO send both authorized and eligible amounts in case of slashing from child app
-        uint96 eligibleAmount = getEligibleAmount(_info);
-        childApplication.updateAuthorization(_stakingProvider, eligibleAmount);
+        childApplication.updateAuthorization(
+            _stakingProvider,
+            _info.authorized,
+            _info.deauthorizing,
+            _info.endDeauthorization
+        );
     }
 
     /**
@@ -885,7 +903,13 @@ contract TACoApplication is
     function manualChildSynchronization(address _stakingProvider) external {
         require(_stakingProvider != address(0), "Staking provider must be specified");
         StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
-        emit ManualChildSynchronizationSent(_stakingProvider, info.authorized, info.operator);
+        emit ManualChildSynchronizationSent(
+            _stakingProvider,
+            info.authorized,
+            info.deauthorizing,
+            info.endDeauthorization,
+            info.operator
+        );
         _updateAuthorization(_stakingProvider, info);
         childApplication.updateOperator(_stakingProvider, info.operator);
     }

--- a/contracts/contracts/coordination/ITACoRootToChild.sol
+++ b/contracts/contracts/coordination/ITACoRootToChild.sol
@@ -8,9 +8,21 @@ pragma solidity ^0.8.0;
  */
 interface ITACoRootToChild {
     event OperatorUpdated(address indexed stakingProvider, address indexed operator);
-    event AuthorizationUpdated(address indexed stakingProvider, uint96 amount);
+    event AuthorizationUpdated(
+        address indexed stakingProvider,
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization
+    );
 
     function updateOperator(address stakingProvider, address operator) external;
 
-    function updateAuthorization(address stakingProvider, uint96 amount) external;
+    function updateAuthorization(address stakingProvider, uint96 authorized) external;
+
+    function updateAuthorization(
+        address stakingProvider,
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization
+    ) external;
 }

--- a/contracts/contracts/coordination/TACoChildApplication.sol
+++ b/contracts/contracts/coordination/TACoChildApplication.sol
@@ -19,6 +19,8 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         uint96 authorized;
         bool operatorConfirmed;
         uint248 index; // index in stakingProviders array + 1
+        uint96 deauthorizing;
+        uint64 endDeauthorization;
     }
 
     ITACoChildToRoot public immutable rootApplication;
@@ -66,6 +68,27 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         return stakingProviderInfo[_stakingProvider].authorized;
     }
 
+    /**
+     * @notice Returns the amount of stake that is pending authorization
+     *         decrease for the given staking provider. If no authorization
+     *         decrease has been requested, returns zero.
+     */
+    function pendingAuthorizationDecrease(address _stakingProvider) external view returns (uint96) {
+        return stakingProviderInfo[_stakingProvider].deauthorizing;
+    }
+
+    function eligibleStake(
+        address _stakingProvider,
+        uint256 _endDate
+    ) public view returns (uint96) {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        uint96 eligibleAmount = info.endDeauthorization == 0 || info.endDeauthorization >= _endDate
+            ? info.authorized
+            : info.authorized - info.deauthorizing;
+
+        return eligibleAmount;
+    }
+
     function updateOperator(
         address stakingProvider,
         address operator
@@ -73,11 +96,21 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         _updateOperator(stakingProvider, operator);
     }
 
+    // TODO only for backward compatibility
     function updateAuthorization(
         address stakingProvider,
-        uint96 amount
+        uint96 authorized
     ) external override onlyRootApplication {
-        _updateAuthorization(stakingProvider, amount);
+        _updateAuthorization(stakingProvider, authorized, 0, 0);
+    }
+
+    function updateAuthorization(
+        address stakingProvider,
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization
+    ) external override onlyRootApplication {
+        _updateAuthorization(stakingProvider, authorized, deauthorizing, endDeauthorization);
     }
 
     function _updateOperator(address stakingProvider, address operator) internal {
@@ -105,14 +138,27 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         emit OperatorUpdated(stakingProvider, operator);
     }
 
-    function _updateAuthorization(address stakingProvider, uint96 amount) internal {
+    function _updateAuthorization(
+        address stakingProvider,
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization
+    ) internal {
         StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
-        uint96 fromAmount = info.authorized;
 
-        if (stakingProvider != address(0) && amount != fromAmount) {
-            info.authorized = amount;
-            emit AuthorizationUpdated(stakingProvider, amount);
+        if (
+            stakingProvider == address(0) ||
+            (authorized == info.authorized &&
+                deauthorizing == info.deauthorizing &&
+                endDeauthorization == info.endDeauthorization)
+        ) {
+            return;
         }
+
+        info.authorized = authorized;
+        info.deauthorizing = deauthorizing;
+        info.endDeauthorization = endDeauthorization;
+        emit AuthorizationUpdated(stakingProvider, authorized, deauthorizing, endDeauthorization);
     }
 
     function confirmOperatorAddress(address _operator) external override {
@@ -141,6 +187,7 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
      * @notice Get the value of authorized tokens for active providers as well as providers and their authorized tokens
      * @param _startIndex Start index for looking in providers array
      * @param _maxStakingProviders Max providers for looking, if set 0 then all will be used
+     * @param _cohortDuration Duration during which staking provider should be active. 0 means no end date
      * @return allAuthorizedTokens Sum of authorized tokens for active providers
      * @return activeStakingProviders Array of providers and their authorized tokens.
      * Providers addresses stored together with amounts as bytes32
@@ -149,8 +196,9 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
      */
     function getActiveStakingProviders(
         uint256 _startIndex,
-        uint256 _maxStakingProviders
-    ) external view returns (uint96 allAuthorizedTokens, bytes32[] memory activeStakingProviders) {
+        uint256 _maxStakingProviders,
+        uint32 _cohortDuration
+    ) public view returns (uint96 allAuthorizedTokens, bytes32[] memory activeStakingProviders) {
         uint256 endIndex = stakingProviders.length;
         require(_startIndex < endIndex, "Wrong start index");
         if (_maxStakingProviders != 0 && _startIndex + _maxStakingProviders < endIndex) {
@@ -158,12 +206,15 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         }
         activeStakingProviders = new bytes32[](endIndex - _startIndex);
         allAuthorizedTokens = 0;
+        uint256 endDate = _cohortDuration == 0
+            ? type(uint256).max
+            : block.timestamp + _cohortDuration;
 
         uint256 resultIndex = 0;
         for (uint256 i = _startIndex; i < endIndex; i++) {
             address stakingProvider = stakingProviders[i];
             StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
-            uint96 eligibleAmount = info.authorized;
+            uint96 eligibleAmount = eligibleStake(stakingProvider, endDate);
             if (eligibleAmount < minimumAuthorization || !info.operatorConfirmed) {
                 continue;
             }
@@ -177,6 +228,14 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
         assembly {
             mstore(activeStakingProviders, resultIndex)
         }
+    }
+
+    // TODO only for backward compatibility
+    function getActiveStakingProviders(
+        uint256 _startIndex,
+        uint256 _maxStakingProviders
+    ) external view returns (uint96 allAuthorizedTokens, bytes32[] memory activeStakingProviders) {
+        return getActiveStakingProviders(_startIndex, _maxStakingProviders, 0);
     }
 }
 
@@ -204,8 +263,10 @@ contract TestnetTACoChildApplication is AccessControlUpgradeable, TACoChildAppli
 
     function forceUpdateAuthorization(
         address stakingProvider,
-        uint96 amount
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization
     ) external onlyRole(UPDATE_ROLE) {
-        _updateAuthorization(stakingProvider, amount);
+        _updateAuthorization(stakingProvider, authorized, deauthorizing, endDeauthorization);
     }
 }

--- a/contracts/contracts/testnet/LynxSet.sol
+++ b/contracts/contracts/testnet/LynxSet.sol
@@ -38,7 +38,14 @@ contract MockPolygonRoot is Ownable, ITACoChildToRoot, ITACoRootToChild {
     function updateOperator(address stakingProvider, address operator) external {}
 
     // solhint-disable-next-line no-empty-blocks
-    function updateAuthorization(address stakingProvider, uint96 amount) external {}
+    function updateAuthorization(address stakingProvider, uint96 authorized) external {}
+
+    function updateAuthorization(
+        address stakingProvider,
+        uint96 authorized,
+        uint96 deauthorizing,
+        uint64 endDeauthorization // solhint-disable-next-line no-empty-blocks
+    ) external {}
 }
 
 contract MockPolygonChild is Ownable, ITACoChildToRoot, ITACoRootToChild {
@@ -62,6 +69,20 @@ contract MockPolygonChild is Ownable, ITACoChildToRoot, ITACoRootToChild {
         uint96 _amount
     ) external override onlyOwner {
         childApplication.updateAuthorization(_stakingProvider, _amount);
+    }
+
+    function updateAuthorization(
+        address _stakingProvider,
+        uint96 _authorized,
+        uint96 _deauthorizing,
+        uint64 _endDeauthorization
+    ) external override onlyOwner {
+        childApplication.updateAuthorization(
+            _stakingProvider,
+            _authorized,
+            _deauthorizing,
+            _endDeauthorization
+        );
     }
 
     // solhint-disable-next-line no-empty-blocks

--- a/contracts/test/TACoApplicationTestSet.sol
+++ b/contracts/test/TACoApplicationTestSet.sol
@@ -134,9 +134,15 @@ contract ThresholdStakingForTACoApplicationMock {
  * @notice Contract for testing TACo application contract
  */
 contract ChildApplicationForTACoApplicationMock {
+    struct StakingProviderInfo {
+        uint96 authorized;
+        uint96 deauthorizing;
+        uint64 endDeauthorization;
+    }
+
     TACoApplication public immutable rootApplication;
 
-    mapping(address => uint96) public authorizedStake;
+    mapping(address => StakingProviderInfo) public stakingProviderInfo;
     mapping(address => address) public stakingProviderToOperator;
     mapping(address => address) public operatorToStakingProvider;
 
@@ -151,8 +157,16 @@ contract ChildApplicationForTACoApplicationMock {
         operatorToStakingProvider[_operator] = _stakingProvider;
     }
 
-    function updateAuthorization(address _stakingProvider, uint96 _amount) external {
-        authorizedStake[_stakingProvider] = _amount;
+    function updateAuthorization(
+        address _stakingProvider,
+        uint96 _authorized,
+        uint96 _deauthorizing,
+        uint64 _endDeauthorization
+    ) external {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        info.authorized = _authorized;
+        info.deauthorizing = _deauthorizing;
+        info.endDeauthorization = _endDeauthorization;
     }
 
     function confirmOperatorAddress(address _operator) external {

--- a/contracts/test/TACoChildApplicationTestSet.sol
+++ b/contracts/test/TACoChildApplicationTestSet.sol
@@ -21,8 +21,22 @@ contract RootApplicationForTACoChildApplicationMock {
         childApplication.updateOperator(_stakingProvider, _operator);
     }
 
-    function updateAuthorization(address _stakingProvider, uint96 _amount) external {
-        childApplication.updateAuthorization(_stakingProvider, _amount);
+    function updateAuthorization(address _stakingProvider, uint96 _authorized) external {
+        childApplication.updateAuthorization(_stakingProvider, _authorized);
+    }
+
+    function updateAuthorization(
+        address _stakingProvider,
+        uint96 _authorized,
+        uint96 _deauthorizing,
+        uint64 _endDeauthorization
+    ) external {
+        childApplication.updateAuthorization(
+            _stakingProvider,
+            _authorized,
+            _deauthorizing,
+            _endDeauthorization
+        );
     }
 
     function confirmOperatorAddress(address _operator) external {

--- a/tests/application/test_operator.py
+++ b/tests/application/test_operator.py
@@ -102,7 +102,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert child_application.operatorToStakingProvider(operator1) == staking_provider_3
 
     # No active stakingProviders before confirmation
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0, 0)
     assert all_locked == 0
     assert len(staking_providers) == 0
 
@@ -123,7 +123,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     ]
 
     # After confirmation operator is becoming active
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0, 0)
     assert all_locked == min_authorization
     assert len(staking_providers) == 1
     assert to_checksum_address(staking_providers[0][0:20]) == staking_provider_3
@@ -162,7 +162,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert child_application.operatorToStakingProvider(operator1) == ZERO_ADDRESS
 
     # Resetting operator removes from active list before next confirmation
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0, 0)
     assert all_locked == 0
     assert len(staking_providers) == 0
 
@@ -264,7 +264,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     assert child_application.operatorToStakingProvider(operator3) == staking_provider_4
 
     # Resetting operator removes from active list before next confirmation
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(1, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(1, 0, 0)
     assert all_locked == 0
     assert len(staking_providers) == 0
 
@@ -323,7 +323,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     threshold_staking.authorizationIncreased(
         staking_provider_1, min_authorization - 1, min_authorization, sender=creator
     )
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(0, 0, 0)
     assert all_locked == 2 * min_authorization
     assert len(staking_providers) == 2
     assert to_checksum_address(staking_providers[0][0:20]) == staking_provider_3
@@ -333,7 +333,7 @@ def test_bond_operator(accounts, threshold_staking, taco_application, child_appl
     threshold_staking.involuntaryAuthorizationDecrease(
         staking_provider_1, min_authorization, min_authorization - 1, sender=creator
     )
-    all_locked, staking_providers = taco_application.getActiveStakingProviders(1, 0)
+    all_locked, staking_providers = taco_application.getActiveStakingProviders(1, 0, 0)
     assert all_locked == 0
     assert len(staking_providers) == 0
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Root -> Child TACo bridge now syncs deauth amount and end of deauth. 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
To allow confirmation based on authorized amount only (without deauth amount)

**Notes for reviewers:**
TACo child upgrade should be done first, otherwise bridge syncing could be an issue. Even if it will occur it can be solved with calling manual method later
