### PR TITLE
Release `@nucypher-contracts@0.21.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/nucypher-contracts",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "AGPL-3.0-or-later",
   "description": "Threshold Access Control (TACo) Smart Contracts",
   "author": "NuCypher",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0
+current_version = 0.21.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/test/registry.spec.ts
+++ b/test/registry.spec.ts
@@ -18,7 +18,7 @@ describe("registry", () => {
   );
 
   it("should throw for invalid domain", () => {
-    expect(() => getContract("invalid-domain", 80001, "Coordinator")).toThrow();
+    expect(() => getContract("invalid-domain", 80002, "Coordinator")).toThrow();
   });
 
   it("should throw for invalid chainId", () => {
@@ -26,7 +26,7 @@ describe("registry", () => {
   });
 
   it("should throw for invalid contract", () => {
-    expect(() => getContract("lynx", 80001, "InvalidContract")).toThrow();
+    expect(() => getContract("lynx", 80002, "InvalidContract")).toThrow();
   });
 
   it("should return the same contract address for the same domain, chainId, and contract", () => {


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**Notes for reviewers:**
- Tested in https://github.com/nucypher/taco-web/pull/507
- Released on npmjs.com
- Tagged on GH with `lynx`