### PR TITLE
Penalty for reward as alternative to slashing

### DIFF
--- a/contracts/contracts/TACoApplication.sol
+++ b/contracts/contracts/TACoApplication.sol
@@ -167,25 +167,45 @@ contract TACoApplication is
         address operator
     );
 
+    /**
+     * @notice Signals that the staking provider was penalized
+     * @param stakingProvider Staking provider address
+     * @param penaltyPercent Percent of reward that was penalized
+     * @param endPenalty End of penalty
+     */
+    event Penalized(address indexed stakingProvider, uint256 penaltyPercent, uint256 endPenalty);
+
+    /**
+     * @notice Signals that reward was reset after penalty
+     * @param stakingProvider Staking provider address
+     */
+    event RewardReset(address indexed stakingProvider);
+
     struct StakingProviderInfo {
         address operator;
         bool operatorConfirmed;
         uint64 operatorStartTimestamp;
         uint96 authorized;
-        uint96 deauthorizing; // TODO real usage only in getActiveStakingProviders, maybe remove?
+        uint96 deauthorizing;
         uint64 endDeauthorization;
         uint96 tReward;
         uint160 rewardPerTokenPaid;
         uint64 endCommitment;
+        uint256 stub;
+        uint192 penaltyPercent;
+        uint64 endPenalty;
     }
 
     uint256 public constant REWARD_PER_TOKEN_MULTIPLIER = 10 ** 3;
     uint256 internal constant FLOATING_POINT_DIVISOR = REWARD_PER_TOKEN_MULTIPLIER * 10 ** 18;
+    uint256 public constant PENALTY_BASE = 10000;
 
     uint96 public immutable minimumAuthorization;
     uint256 public immutable minOperatorSeconds;
     uint256 public immutable rewardDuration;
     uint256 public immutable deauthorizationDuration;
+    uint192 public immutable penaltyDefault;
+    uint256 public immutable penaltyDuration;
 
     uint64 public immutable commitmentDurationOption1;
     uint64 public immutable commitmentDurationOption2;
@@ -222,6 +242,8 @@ contract TACoApplication is
      * @param _deauthorizationDuration Duration of decreasing authorization in seconds
      * @param _commitmentDurationOptions Options for commitment duration
      * @param _commitmentDeadline Last date to make a commitment
+     * @param _penaltyDefault Default penalty percentage
+     * @param _penaltyDuration Duration of penalty
      */
     constructor(
         IERC20 _token,
@@ -231,7 +253,9 @@ contract TACoApplication is
         uint256 _rewardDuration,
         uint256 _deauthorizationDuration,
         uint64[] memory _commitmentDurationOptions,
-        uint64 _commitmentDeadline
+        uint64 _commitmentDeadline,
+        uint192 _penaltyDefault,
+        uint256 _penaltyDuration
     ) {
         uint256 totalSupply = _token.totalSupply();
         require(
@@ -239,7 +263,10 @@ contract TACoApplication is
                 _tStaking.authorizedStake(address(this), address(this)) == 0 &&
                 totalSupply > 0 &&
                 _commitmentDurationOptions.length >= 1 &&
-                _commitmentDurationOptions.length <= 4,
+                _commitmentDurationOptions.length <= 4 &&
+                _penaltyDefault > 0 &&
+                _penaltyDefault < PENALTY_BASE &&
+                _penaltyDuration > 0,
             "Wrong input parameters"
         );
         // This require is only to check potential overflow for 10% reward
@@ -266,6 +293,8 @@ contract TACoApplication is
             ? _commitmentDurationOptions[3]
             : 0;
         commitmentDeadline = _commitmentDeadline;
+        penaltyDefault = _penaltyDefault;
+        penaltyDuration = _penaltyDuration;
         _disableInitializers();
     }
 
@@ -420,10 +449,44 @@ contract TACoApplication is
         if (!info.operatorConfirmed) {
             return info.tReward;
         }
-        uint256 result = (uint256(info.authorized) * (rewardPerToken() - info.rewardPerTokenPaid)) /
+        uint96 authorized = effectiveAuthorized(info.authorized, info);
+        uint256 result = (uint256(authorized) * (rewardPerToken() - info.rewardPerTokenPaid)) /
             FLOATING_POINT_DIVISOR +
             info.tReward;
         return result.toUint96();
+    }
+
+    // FIXME
+    function effectiveAuthorized(
+        uint96 _authorized,
+        uint192 _penaltyPercent
+    ) internal view returns (uint96) {
+        return uint96((_authorized * (PENALTY_BASE - _penaltyPercent)) / PENALTY_BASE);
+    }
+
+    function effectiveAuthorized(
+        uint96 _authorized,
+        StakingProviderInfo storage _info
+    ) internal view returns (uint96) {
+        if (_info.endPenalty != 0 && _info.endPenalty > block.timestamp) {
+            return effectiveAuthorized(_authorized, _info.penaltyPercent);
+        } else {
+            return _info.authorized;
+        }
+    }
+
+    function effectiveDifference(
+        uint96 _from,
+        uint96 _to,
+        StakingProviderInfo storage _info
+    ) internal view returns (uint96) {
+        if (_info.endPenalty != 0 && _info.endPenalty > block.timestamp) {
+            uint96 effectiveFrom = effectiveAuthorized(_from, _info.penaltyPercent);
+            uint96 effectiveTo = effectiveAuthorized(_to, _info.penaltyPercent);
+            return effectiveFrom - effectiveTo;
+        } else {
+            return _from - _to;
+        }
     }
 
     /**
@@ -477,7 +540,7 @@ contract TACoApplication is
         uint96 _properAmount
     ) internal {
         if (_info.authorized != _properAmount) {
-            authorizedOverall -= _info.authorized - _properAmount;
+            authorizedOverall -= effectiveDifference(_info.authorized, _properAmount, _info);
         }
     }
 
@@ -507,7 +570,7 @@ contract TACoApplication is
 
         if (info.operatorConfirmed) {
             resynchronizeAuthorizedOverall(info, _fromAmount);
-            authorizedOverall += _toAmount - _fromAmount;
+            authorizedOverall += effectiveDifference(_toAmount, _fromAmount, info);
         }
 
         info.authorized = _toAmount;
@@ -529,7 +592,7 @@ contract TACoApplication is
         StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         if (info.operatorConfirmed) {
             resynchronizeAuthorizedOverall(info, _fromAmount);
-            authorizedOverall -= _fromAmount - _toAmount;
+            authorizedOverall -= effectiveDifference(_fromAmount, _toAmount, info);
         }
 
         info.authorized = _toAmount;
@@ -593,7 +656,7 @@ contract TACoApplication is
         uint96 toAmount = tStaking.approveAuthorizationDecrease(_stakingProvider);
 
         if (info.operatorConfirmed) {
-            authorizedOverall -= info.authorized - toAmount;
+            authorizedOverall -= effectiveDifference(info.authorized, toAmount, info);
         }
 
         emit AuthorizationDecreaseApproved(_stakingProvider, info.authorized, toAmount);
@@ -619,7 +682,7 @@ contract TACoApplication is
         require(info.authorized > newAuthorized, "Nothing to synchronize");
 
         if (info.operatorConfirmed) {
-            authorizedOverall -= info.authorized - newAuthorized;
+            authorizedOverall -= effectiveDifference(info.authorized, newAuthorized, info);
         }
         emit AuthorizationReSynchronized(_stakingProvider, info.authorized, newAuthorized);
 
@@ -860,7 +923,7 @@ contract TACoApplication is
         }
 
         if (info.operatorConfirmed) {
-            authorizedOverall -= info.authorized;
+            authorizedOverall -= effectiveAuthorized(info.authorized, info);
         }
 
         // Bond new operator (or unbond if _operator == address(0))
@@ -891,7 +954,7 @@ contract TACoApplication is
         if (!info.operatorConfirmed) {
             updateRewardInternal(stakingProvider);
             info.operatorConfirmed = true;
-            authorizedOverall += info.authorized;
+            authorizedOverall += effectiveAuthorized(info.authorized, info);
             emit OperatorConfirmed(stakingProvider, _operator);
         }
     }
@@ -956,5 +1019,33 @@ contract TACoApplication is
         address[] memory stakingProviderWrapper = new address[](1);
         stakingProviderWrapper[0] = _stakingProvider;
         tStaking.seize(_penalty, 100, _investigator, stakingProviderWrapper);
+    }
+
+    /**
+     * @notice Penalize the staking provider's future reward
+     * @param _stakingProvider Staking provider address
+     */
+    function penalize(address _stakingProvider) external updateReward(_stakingProvider) {
+        require(
+            msg.sender == address(childApplication),
+            "Only child application allowed to penalize"
+        );
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        info.penaltyPercent = penaltyDefault;
+        info.endPenalty = uint64(block.timestamp + penaltyDuration);
+        emit Penalized(_stakingProvider, info.penaltyPercent, info.endPenalty);
+    }
+
+    /**
+     * @notice Resets future reward back to 100%
+     * @param _stakingProvider Staking provider address
+     */
+    function resetReward(address _stakingProvider) external updateReward(_stakingProvider) {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        require(info.endPenalty != 0, "There are no any penalties");
+        require(info.endPenalty <= block.timestamp, "Penalty is still ongoing");
+        info.endPenalty = 0;
+        info.penaltyPercent = 0;
+        emit RewardReset(_stakingProvider);
     }
 }

--- a/contracts/contracts/coordination/ITACoChildToRoot.sol
+++ b/contracts/contracts/coordination/ITACoChildToRoot.sol
@@ -15,4 +15,6 @@ interface ITACoChildToRoot {
     event OperatorConfirmed(address indexed stakingProvider, address indexed operator);
 
     function confirmOperatorAddress(address operator) external;
+
+    function penalize(address stakingProvider) external;
 }

--- a/contracts/contracts/coordination/TACoChildApplication.sol
+++ b/contracts/contracts/coordination/TACoChildApplication.sol
@@ -62,7 +62,7 @@ contract TACoChildApplication is ITACoRootToChild, ITACoChildApplication, Initia
      * @notice Initialize function for using with OpenZeppelin proxy
      */
     function initialize(address _coordinator, address _adjudicator) external initializer {
-        require(coordinator == address(0) || _adjudicator == address(0), "Contracts already set");
+        require(coordinator == address(0) || adjudicator == address(0), "Contracts already set");
         require(
             _coordinator != address(0) && _adjudicator != address(0),
             "Contracts must be specified"

--- a/contracts/contracts/testnet/LynxSet.sol
+++ b/contracts/contracts/testnet/LynxSet.sol
@@ -34,6 +34,10 @@ contract MockPolygonRoot is Ownable, ITACoChildToRoot, ITACoRootToChild {
         rootApplication.confirmOperatorAddress(operator);
     }
 
+    function penalize(address _stakingProvider) external override onlyOwner {
+        rootApplication.penalize(_stakingProvider);
+    }
+
     // solhint-disable-next-line no-empty-blocks
     function updateOperator(address stakingProvider, address operator) external {}
 
@@ -87,6 +91,9 @@ contract MockPolygonChild is Ownable, ITACoChildToRoot, ITACoRootToChild {
 
     // solhint-disable-next-line no-empty-blocks
     function confirmOperatorAddress(address _operator) external override {}
+
+    // solhint-disable-next-line no-empty-blocks
+    function penalize(address _stakingProvider) external override {}
 }
 
 contract LynxRitualToken is ERC20("LynxRitualToken", "LRT") {

--- a/contracts/test/CoordinatorTestSet.sol
+++ b/contracts/test/CoordinatorTestSet.sol
@@ -29,6 +29,9 @@ contract ChildApplicationForCoordinatorMock is ITACoChildApplication {
     function confirmOperatorAddress(address _operator) external {
         confirmations[_operator] = true;
     }
+
+    // solhint-disable-next-line no-empty-blocks
+    function penalize(address _stakingProvider) external {}
 }
 
 // /**

--- a/contracts/test/TACoApplicationTestSet.sol
+++ b/contracts/test/TACoApplicationTestSet.sol
@@ -172,4 +172,8 @@ contract ChildApplicationForTACoApplicationMock {
     function confirmOperatorAddress(address _operator) external {
         rootApplication.confirmOperatorAddress(_operator);
     }
+
+    function penalize(address _stakingProvider) external {
+        rootApplication.penalize(_stakingProvider);
+    }
 }

--- a/contracts/test/TACoChildApplicationTestSet.sol
+++ b/contracts/test/TACoChildApplicationTestSet.sol
@@ -12,6 +12,7 @@ contract RootApplicationForTACoChildApplicationMock {
     ITACoRootToChild public childApplication;
 
     mapping(address => bool) public confirmations;
+    mapping(address => bool) public penalties;
 
     function setChildApplication(ITACoRootToChild _childApplication) external {
         childApplication = _childApplication;
@@ -41,6 +42,10 @@ contract RootApplicationForTACoChildApplicationMock {
 
     function confirmOperatorAddress(address _operator) external {
         confirmations[_operator] = true;
+    }
+
+    function penalize(address _stakingProvider) external {
+        penalties[_stakingProvider] = true;
     }
 
     function resetConfirmation(address _operator) external {

--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -29,7 +29,7 @@ DEAUTHORIZATION_DURATION = 60 * 60 * 24 * 60  # 60 days in seconds
 COMMITMENT_DURATION_1 = 182 * 60 * 24 * 60  # 182 days in seconds
 COMMITMENT_DURATION_2 = 2 * COMMITMENT_DURATION_1  # 365 days in seconds
 COMMITMENT_DURATION_3 = 3 * COMMITMENT_DURATION_1  # 365 days in seconds
-COMMITMENT_DEADLINE = 60 * 60 * 24 * 100  # 100 days after deploymwent
+COMMITMENT_DEADLINE = 60 * 60 * 24 * 200  # 200 days after deploymwent
 
 PENALTY_DEFAULT = 1000  # 10% penalty
 PENALTY_DURATION = 60 * 60 * 24  # 1 day in seconds

--- a/tests/application/conftest.py
+++ b/tests/application/conftest.py
@@ -31,6 +31,9 @@ COMMITMENT_DURATION_2 = 2 * COMMITMENT_DURATION_1  # 365 days in seconds
 COMMITMENT_DURATION_3 = 3 * COMMITMENT_DURATION_1  # 365 days in seconds
 COMMITMENT_DEADLINE = 60 * 60 * 24 * 100  # 100 days after deploymwent
 
+PENALTY_DEFAULT = 1000  # 10% penalty
+PENALTY_DURATION = 60 * 60 * 24  # 1 day in seconds
+
 
 @pytest.fixture()
 def token(project, accounts):
@@ -78,6 +81,8 @@ def taco_application(project, creator, token, threshold_staking, oz_dependency, 
         DEAUTHORIZATION_DURATION,
         [COMMITMENT_DURATION_1, COMMITMENT_DURATION_2, COMMITMENT_DURATION_3],
         now + COMMITMENT_DEADLINE,
+        PENALTY_DEFAULT,
+        PENALTY_DURATION,
     )
 
     encoded_initializer_function = encode_function_data()

--- a/tests/application/test_authorization.py
+++ b/tests/application/test_authorization.py
@@ -25,6 +25,8 @@ END_DEAUTHORIZATION_SLOT = 5
 END_COMMITMENT_SLOT = 8
 MIN_AUTHORIZATION = Web3.to_wei(40_000, "ether")
 DEAUTHORIZATION_DURATION = 60 * 60 * 24 * 60  # 60 days in seconds
+PENALTY_DEFAULT = 1000  # 10% penalty
+PENALTY_DURATION = 60 * 60 * 24  # 1 day in seconds
 
 
 def test_authorization_parameters(taco_application):

--- a/tests/application/test_operator.py
+++ b/tests/application/test_operator.py
@@ -529,7 +529,7 @@ def test_reset_reward(accounts, threshold_staking, taco_application, child_appli
     min_authorization = MIN_AUTHORIZATION
 
     # This method only for penalized staking providers
-    with ape.reverts("There are no any penalties"):
+    with ape.reverts("There is no penalty"):
         taco_application.resetReward(staking_provider, sender=creator)
 
     # Penalize staking provider

--- a/tests/application/test_reward.py
+++ b/tests/application/test_reward.py
@@ -28,6 +28,7 @@ REWARD_DURATION = 60 * 60 * 24 * 7  # one week in seconds
 DEAUTHORIZATION_DURATION = 60 * 60 * 24 * 60  # 60 days in seconds
 FLOATING_POINT_DIVISOR = 10**21
 REWARD_PORTION = MIN_AUTHORIZATION * 10**3
+PENALTY_DURATION = 60 * 60 * 24  # 1 day in seconds
 
 
 def test_push_reward(
@@ -248,6 +249,15 @@ def test_update_reward(
     taco_application.resynchronizeAuthorization(staking_provider_2, sender=creator)
     check_reward_no_confirmation()
 
+    # Penalize staking provider, no confirmed operator
+    child_application.penalize(staking_provider_2, sender=creator)
+    check_reward_no_confirmation()
+
+    # Reset reward after penalty, no confirmed operator
+    chain.pending_timestamp += PENALTY_DURATION
+    taco_application.resetReward(staking_provider_2, sender=creator)
+    check_reward_no_confirmation()
+
     # Wait and confirm operator
     taco_application.pushReward(reward_portion, sender=distributor)
     chain.pending_timestamp += reward_duration // 2
@@ -287,6 +297,15 @@ def test_update_reward(
     chain.pending_timestamp += reward_duration // 2
     threshold_staking.setAuthorized(staking_provider_2, value, sender=creator)
     taco_application.resynchronizeAuthorization(staking_provider_2, sender=creator)
+    check_reward_with_confirmation()
+
+    # Penalize staking provider with confirmation
+    child_application.penalize(staking_provider_2, sender=creator)
+    check_reward_with_confirmation()
+
+    # Reset reward after penalty, with confirmation
+    chain.pending_timestamp += PENALTY_DURATION
+    taco_application.resetReward(staking_provider_2, sender=creator)
     check_reward_with_confirmation()
 
     # Bond operator with confirmation (confirmation will be dropped)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Penalize reward as an option when slashing is too much. Penalty decreases reward by `penaltyDefault` for `penaltyDuration`. Each `penalize` restarts time, penalty itself is the same value until end of duration. Initially this event starts on Polygon in child app, where `penalize` can be called by special role (`adjudicator` for now)

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
