### PR TITLE
Script that lists all the active rituals that a specified staking provider is participating in

### DIFF
--- a/scripts/ritual_membership.py
+++ b/scripts/ritual_membership.py
@@ -1,0 +1,63 @@
+import click
+from ape import networks, project
+from ape.cli import ConnectedProviderCommand, network_option
+from eth_typing import ChecksumAddress
+from eth_utils import to_checksum_address
+
+from deployment.constants import SUPPORTED_TACO_DOMAINS
+from deployment.registry import contracts_from_registry
+from deployment.utils import registry_filepath_from_domain
+
+
+@click.command(cls=ConnectedProviderCommand)
+@network_option(required=True)
+@click.option(
+    "--domain",
+    "-d",
+    help="TACo domain",
+    type=click.Choice(SUPPORTED_TACO_DOMAINS),
+    required=True,
+)
+@click.option(
+    "--staking-provider-address",
+    "-p",
+    help="Staking provider address to check",
+    type=ChecksumAddress,
+    required=True,
+)
+def cli(network, domain, staking_provider_address):
+    """Lists all the active rituals that a staking provider is participating in."""
+    registry_filepath = registry_filepath_from_domain(domain=domain)
+    contracts = contracts_from_registry(
+        registry_filepath, chain_id=networks.active_provider.chain_id
+    )
+
+    provider_checksum_address = to_checksum_address(staking_provider_address)
+    # lower used for comparing against sorted list
+    provider_checksum_address_lower = provider_checksum_address.lower()
+
+    coordinator = project.Coordinator.at(contracts["Coordinator"].address)
+    num_rituals = coordinator.numberOfRituals()
+
+    ritual_memberships = []
+    for ritual_id in range(0, num_rituals):
+        if not coordinator.isRitualActive(ritual_id):
+            continue
+
+        participants = coordinator.getParticipants(ritual_id)
+        for participant in participants:
+            provider = participant.provider
+            if provider == provider_checksum_address:
+                ritual_memberships.append(ritual_id)
+                break
+            if provider_checksum_address_lower < provider:
+                # list of participants is sorted so stop early if already passed
+                break
+
+    if not ritual_memberships:
+        print(f"\nStaking provider {provider_checksum_address} is not part of any rituals")
+        return
+
+    print("\nActive Ritual Memberships:")
+    for ritual_id in ritual_memberships:
+        print(f"\t- ID: #{ritual_id}")


### PR DESCRIPTION


**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

```
ape run ritual_membership --network polygon:mainnet:infura --domain mainnet --staking-provider-address <>
```

I used this script to check rituals that a provider that no longer had their original keystore was a part of, and figured it could be helpful in other investigations.

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/sprints/issues/47

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
