### PR TITLE
Add duration calculation for subscription based rituals

### DIFF
--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -120,10 +120,13 @@ def cli(
             + fee_model_contract.redPeriodDuration()
         )
         if start_of_subscription > 0:
+            end_of_subscription = fee_model_contract.getEndOfSubscription()
+            now = chain.blocks.head.timestamp
+            if now > end_of_subscription:
+                raise ValueError("Subscription has already ended.")
             click.echo(
             "Subscription has already started. Subtracting the elapsed time from the duration."
         )
-            now = chain.blocks.head.timestamp
             elapsed = now - start_of_subscription + 100
             duration -= elapsed
 


### PR DESCRIPTION
If anyone wants to test it here is the command:

`ape run initiate_ritual --network polygon:amoy:infura -d lynx -c GlobalAllowList -f BqETHSubscription -a 0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600 --num-nodes 3`