### PR TITLE
Undo previous change regarding how receipts were obtained

### DIFF
--- a/deployment/registry.py
+++ b/deployment/registry.py
@@ -5,17 +5,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional
 
-from ape import chain, project
+from ape import project
 from ape.contracts import ContractInstance
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
 from web3.types import ABI
 
-from deployment.utils import (
-    _load_json,
-    get_contract_container,
-    registry_filepath_from_domain
-)
+from deployment.utils import _load_json, get_contract_container, registry_filepath_from_domain
 
 ChainId = int
 ContractName = str
@@ -68,7 +64,7 @@ def _get_entry(
 ) -> RegistryEntry:
     contract_abi = _get_abi(contract_instance)
     contract_name = _get_name(contract_instance=contract_instance, registry_names=registry_names)
-    receipt = chain.get_receipt(contract_instance.txn_hash)
+    receipt = contract_instance.receipt
     entry = RegistryEntry(
         name=contract_name,
         address=to_checksum_address(contract_instance.address),


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Undo https://github.com/nucypher/nucypher-contracts/commit/fd87a1136f995aa3433e7fd0129f582d107f7716 which applied to `ape` `0.8.8` but is not applicable for `0.7.x` which is the current version of ape used in dependencies, and what we currently use. Revert for now since it is causing issues with deployment scripts when writing to the registry, since the receipt cannot be found.

In the (near?) future, we will relock dependencies to rely on a `0.8.x` version of `ape`, and then the original change may be applicable again.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
