### PR TITLE
Fix use of Porter for sampling

### DIFF
--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -195,6 +195,11 @@ def sample_nodes(
     response.raise_for_status()
 
     data = response.json()
-    result = sorted(data["result"]["ursulas"], key=lambda x: x.lower())
+    ursulas = data["result"]["ursulas"]
+    if domain != MAINNET:
+        # /get_ursulas is used for sampling (instead of /bucket_sampling)
+        #  so the json returned is slightly different
+        ursulas = [u["checksum_address"] for u in ursulas]
 
+    result = sorted(ursulas, key=lambda x: x.lower())
     return result

--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -9,7 +9,7 @@ from ape import networks, project
 from ape.contracts import ContractContainer, ContractInstance
 from ape_etherscan.utils import API_KEY_ENV_KEY_MAP
 
-from deployment.constants import ARTIFACTS_DIR, LYNX, MAINNET, PORTER_SAMPLING_ENDPOINTS, TAPIR
+from deployment.constants import ARTIFACTS_DIR, MAINNET, PORTER_SAMPLING_ENDPOINTS
 from deployment.networks import is_local_network
 
 
@@ -192,6 +192,8 @@ def sample_nodes(
         params["min_version"] = min_version
 
     response = requests.get(porter_endpoint, params=params)
+    response.raise_for_status()
+
     data = response.json()
     result = sorted(data["result"]["ursulas"], key=lambda x: x.lower())
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

- Raise an exception whenever the request to Porter fails
- On testnets `/get_ursulas` is used instead of `/bucket_sampling` so we should adjust parsing of response appropriately.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
