### PR TITLE
Fix act command parameters

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,18 +1,18 @@
 # How to run the DKG workflow locally with act
 
-To run the DKG workflow locally, you need to have act installed. 
+To run the DKG workflow locally, you need to have act installed.
 
 https://github.com/nektos/act
 
-Verify the values in `.env.lynx.act` and `.secrets` file completed with the 
+Verify the values in `.env.lynx.act` and `.secrets` file completed with the
 necessary environment variables (see the template files in the same directory `.secrets.act.template`).
 
 Then you can run the following command:
 
 ```bash
 act workflow_dispatch -j initiate_dkg \
---env-file .github/.env.lynx.act \
---secret-file .github/.secrets \
+--var-file .github/.env.lynx.act \
+--secret-file .github/.secrets.act \
 --container-architecture linux/amd64 \
 --artifact-server-path /tmp/artifacts
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ env
 .cache/
 dist/
 .cosine/
-.github/.secrets
+.github/.secrets.act


### PR DESCRIPTION
Fix parameters given as example on README.md

Without this change, ACT didn't detect the values on the .env.lynx.act file, leaving the variables values as blank:

```
[Heartbeat DKG/initiate_dkg]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/4] user= workdir=
| Heartbeat: Initiate Ritual
| Network ::***
| Authority: 
| Access Controller: 
| Fee Model: 
| Duration: 

[...]

| Error: Option '--duration' requires an argument.
```