### PR TITLE
Add support to exclude nodes for initiate_ritual script

### DIFF
--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -235,7 +235,7 @@ def _generate_heartbeat_cohorts(addresses: List[str]) -> Tuple[Tuple[str, ...], 
 
 
 def get_heartbeat_cohorts(
-    taco_application: ContractContainer, excluded_nodes: list
+    taco_application: ContractContainer, excluded_nodes: Optional[List[str]] = []
 ) -> Tuple[Tuple[str, ...], ...]:
     data = taco_application.getActiveStakingProviders(
         0,  # start index

--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-from itertools import zip_longest
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -73,9 +72,7 @@ def validate_config(config: Dict) -> Path:
 
     registry_chain_ids = map(int, _load_json(registry_filepath).keys())
     if config_chain_id in registry_chain_ids:
-        raise ValueError(
-            f"Deployment is already published for chain_id {config_chain_id}."
-        )
+        raise ValueError(f"Deployment is already published for chain_id {config_chain_id}.")
 
     return registry_filepath
 
@@ -217,7 +214,7 @@ def _generate_heartbeat_cohorts(addresses: List[str]) -> Tuple[Tuple[str, ...], 
     we gather them, two by two, like travelers on a shared path.
     Yet, should a lone wanderer remain, we weave them into a final trio—
     a constellation of three, shimmering in quiet order.
-§
+
     Each group, a harmony of case-insensitive sequence,
     arranged with care, untouched in form, yet softened in placement.
 
@@ -227,7 +224,7 @@ def _generate_heartbeat_cohorts(addresses: List[str]) -> Tuple[Tuple[str, ...], 
         raise ValueError("The list of Ethereum addresses cannot be empty.")
 
     # Form pairs, stepping in twos, embracing a final trio if needed
-    groups = [tuple(addresses[i: i + 2]) for i in range(0, len(addresses) - 1, 2)]
+    groups = [tuple(addresses[i : i + 2]) for i in range(0, len(addresses) - 1, 2)]
 
     # If unpaired, merge the last two into a final trio
     if len(addresses) % 2:
@@ -237,7 +234,9 @@ def _generate_heartbeat_cohorts(addresses: List[str]) -> Tuple[Tuple[str, ...], 
     return tuple(map(lambda group: tuple(sorted(group, key=str.lower)), groups))
 
 
-def get_heartbeat_cohorts(taco_application: ContractContainer) -> Tuple[Tuple[str, ...], ...]:
+def get_heartbeat_cohorts(
+    taco_application: ContractContainer, excluded_nodes: list
+) -> Tuple[Tuple[str, ...], ...]:
     data = taco_application.getActiveStakingProviders(
         0,  # start index
         1000,  # max number of staking providers
@@ -249,6 +248,10 @@ def get_heartbeat_cohorts(taco_application: ContractContainer) -> Tuple[Tuple[st
         staking_provider_address = to_checksum_address(info[0:20])
         staking_provider_authorized_tokens = to_int(info[20:32])
         staking_providers[staking_provider_address] = staking_provider_authorized_tokens
+
+    # Exclude nodes that are in the excluded_nodes list
+    for node in excluded_nodes:
+        staking_providers.pop(to_checksum_address(node))
 
     cohorts = _generate_heartbeat_cohorts(list(staking_providers))
     return cohorts

--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -177,6 +177,7 @@ def sample_nodes(
     random_seed: Optional[int] = None,
     duration: Optional[int] = None,
     min_version: Optional[str] = None,
+    excluded_nodes: Optional[List[str]] = None,
 ):
     porter_endpoint = PORTER_SAMPLING_ENDPOINTS.get(domain)
     if not porter_endpoint:
@@ -193,6 +194,9 @@ def sample_nodes(
         params["random_seed"] = random_seed
     if min_version:
         params["min_version"] = min_version
+    if excluded_nodes:
+        nodes = [to_checksum_address(node) for node in excluded_nodes]
+        params["exclude_ursulas"] = ",".join(nodes)
 
     response = requests.get(porter_endpoint, params=params)
     response.raise_for_status()

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -9,10 +9,14 @@ from ape import Contract, chain
 from ape.cli import ConnectedProviderCommand, account_option, network_option
 
 from deployment import registry
-from deployment.constants import ACCESS_CONTROLLERS, SUPPORTED_TACO_DOMAINS, HEARTBEAT_ARTIFACT_FILENAME
+from deployment.constants import (
+    ACCESS_CONTROLLERS,
+    HEARTBEAT_ARTIFACT_FILENAME,
+    SUPPORTED_TACO_DOMAINS,
+)
 from deployment.params import Transactor
 from deployment.types import ChecksumAddress, MinInt
-from deployment.utils import check_plugins, sample_nodes, get_heartbeat_cohorts
+from deployment.utils import check_plugins, get_heartbeat_cohorts, sample_nodes
 
 
 @click.command(cls=ConnectedProviderCommand, name="initiate-ritual")
@@ -161,7 +165,9 @@ def cli(
 
     # Get the staking providers in the ritual cohort
     if heartbeat:
-        taco_application = registry.get_contract(domain=domain, contract_name="TACoChildApplication")
+        taco_application = registry.get_contract(
+            domain=domain, contract_name="TACoChildApplication"
+        )
         cohorts = get_heartbeat_cohorts(taco_application=taco_application)
         click.echo(f"Initiating {len(cohorts)} rituals.")
         if not auto:
@@ -170,7 +176,9 @@ def cli(
         if handpicked:
             cohort = sorted(line.lower().strip() for line in handpicked)
             if not cohort:
-                raise ValueError(f"No staking providers found in the handpicked file {handpicked.name}")
+                raise ValueError(
+                    f"No staking providers found in the handpicked file {handpicked.name}"
+                )
         else:
             cohort = sample_nodes(
                 domain=domain,

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -196,13 +196,13 @@ def cli(
                     f"No staking providers found in the handpicked file {handpicked.name}"
                 )
         else:
-            # TODO: exclude nodes from the excluded_nodes file
             cohort = sample_nodes(
                 domain=domain,
                 num_nodes=num_nodes,
                 duration=duration,
                 random_seed=random_seed,
                 min_version=min_version,
+                excluded_nodes=excluded,
             )
         cohorts = [cohort]
 

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -176,12 +176,11 @@ def cli(
             elapsed = now - start_of_subscription + 100
             duration -= elapsed
 
-    excluded = []
+    # Set the nodes that are excluded from the cohort sampling
+    excluded = [line.strip() for line in excluded_nodes] if excluded_nodes else []
+
     # Get the staking providers in the ritual cohort
     if heartbeat:
-        if excluded_nodes:
-            excluded = [line.strip() for line in excluded_nodes]
-            click.echo(f"Excluding nodes: {excluded}")
         taco_application = registry.get_contract(
             domain=domain, contract_name="TACoChildApplication"
         )

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -81,6 +81,12 @@ from deployment.utils import check_plugins, get_heartbeat_cohorts, sample_nodes
     type=click.File("r"),
 )
 @click.option(
+    "--excluded-nodes",
+    help="The filepath of a file containing newline separated staking provider \
+          addresses that will be excluded from the node selection.",
+    type=click.File("r"),
+)
+@click.option(
     "--auto",
     help="Automatically sign transactions.",
     is_flag=True,
@@ -101,6 +107,7 @@ def cli(
     num_nodes,
     random_seed,
     handpicked,
+    excluded_nodes,
     min_version,
     auto,
     heartbeat,
@@ -124,6 +131,11 @@ def cli(
         raise click.BadOptionUsage(
             option_name="--min-version",
             message="Cannot specify --min-version when using --handpicked.",
+        )
+    if handpicked and excluded_nodes:
+        raise click.BadOptionUsage(
+            option_name="--excluded-nodes",
+            message="Cannot specify --excluded-nodes when using --handpicked.",
         )
     if heartbeat:
         if not duration:
@@ -168,6 +180,7 @@ def cli(
         taco_application = registry.get_contract(
             domain=domain, contract_name="TACoChildApplication"
         )
+        # TODO: exclude nodes from the excluded_nodes file
         cohorts = get_heartbeat_cohorts(taco_application=taco_application)
         click.echo(f"Initiating {len(cohorts)} rituals.")
         if not auto:
@@ -180,6 +193,7 @@ def cli(
                     f"No staking providers found in the handpicked file {handpicked.name}"
                 )
         else:
+            # TODO: exclude nodes from the excluded_nodes file
             cohort = sample_nodes(
                 domain=domain,
                 num_nodes=num_nodes,

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -77,7 +77,8 @@ from deployment.utils import check_plugins, get_heartbeat_cohorts, sample_nodes
 )
 @click.option(
     "--handpicked",
-    help="The filepath of a file containing newline separated staking provider addresses.",
+    help="The filepath of a file containing newline separated staking provider \
+        addresses that will be included in the ritual.",
     type=click.File("r"),
 )
 @click.option(
@@ -175,13 +176,16 @@ def cli(
             elapsed = now - start_of_subscription + 100
             duration -= elapsed
 
+    excluded = []
     # Get the staking providers in the ritual cohort
     if heartbeat:
+        if excluded_nodes:
+            excluded = [line.strip() for line in excluded_nodes]
+            click.echo(f"Excluding nodes: {excluded}")
         taco_application = registry.get_contract(
             domain=domain, contract_name="TACoChildApplication"
         )
-        # TODO: exclude nodes from the excluded_nodes file
-        cohorts = get_heartbeat_cohorts(taco_application=taco_application)
+        cohorts = get_heartbeat_cohorts(taco_application=taco_application, excluded_nodes=excluded)
         click.echo(f"Initiating {len(cohorts)} rituals.")
         if not auto:
             click.confirm(text="Are you sure you want to initiate these rituals?", abort=True)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Add an argument to `initiate_ritual` to specify a list of nodes that will be excluded when initiating a new ritual. This can be used when running heartbeats but also when initiating a ritual for real.

The script will read the staking addresses from a file, similarly as we already do with `--handpicked` argument.

In some cases this is needed to avoid nodes that we already know that are down.
