### PR TITLE
Fix ci

### DIFF
--- a/scripts/ci/deploy_child.py
+++ b/scripts/ci/deploy_child.py
@@ -82,7 +82,7 @@ def main():
             filepath=UPGRADE_PARAMS_FILEPATH,
             verify=VERIFY,
             account=test_account,
-            non_interactive=True,
+            autosign=True,
         )
 
         upgraded_coordinator = upgrade_deployer.upgrade(project.Coordinator, coordinator.address)


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
`deploy_child.py` script was failing on CI.

This change will fix it by using `autosign` parameter instead of the deprecated `non_interactive`.

Non_interactive function was removed on 06f56c58a55b394281db6ee1902bf0f5c1e0d44d.
