### PR TITLE
Move GitHub variables from secrets to vars

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -31,7 +31,10 @@ jobs:
     - name: Evaluate Ritual
       run: .github/scripts/eval_dkg.sh
       env:
-        DOMAIN: ${{ secrets.DOMAIN }}
-        NETWORK: ${{ secrets.NETWORK }}
+        # Secret environment variables (secrets)
         RPC_PROVIDER: ${{ secrets.RPC_PROVIDER }}
-        ECOSYSTEM: ${{ secrets.ECOSYSTEM }}
+
+        # Non-secret environment variables (config)
+        DOMAIN: ${{ vars.DOMAIN }}
+        NETWORK: ${{ vars.NETWORK }}
+        ECOSYSTEM: ${{ vars.ECOSYSTEM }}


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
These environment variables are stored as variables and not secrets in heartbeat.yml workflow. So it makes sense to use the sames in evaluate.yml workflow.