### PR TITLE
Reorganize CI's secrets and vars

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -33,9 +33,10 @@ jobs:
       run: .github/scripts/eval_dkg.sh
       env:
         # Secret environment variables (secrets)
-        RPC_PROVIDER: ${{ secrets.RPC_PROVIDER }}
+        WEB3_INFURA_API_KEY: ${{ secrets.WEB3_INFURA_API_KEY }}
 
         # Non-secret environment variables (config)
         DOMAIN: ${{ vars.DOMAIN }}
         NETWORK: ${{ vars.NETWORK }}
         ECOSYSTEM: ${{ vars.ECOSYSTEM }}
+        RPC_PROVIDER: ${{ secrets.RPC_PROVIDER }}

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -36,7 +36,6 @@ jobs:
 
         # Secret environment variables (secrets)
         APE_ACCOUNTS_automation_PASSPHRASE: ${{ secrets.DKG_INITIATOR_PASSPHRASE }}
-        RPC_PROVIDER: ${{ secrets.RPC_PROVIDER }}
         WEB3_INFURA_API_KEY: ${{ secrets.WEB3_INFURA_API_KEY }}
         POLYGONSCAN_API_KEY: ${{ secrets.POLYGONSCAN_API_KEY }}
         EXCLUDED_NODES: ${{ secrets.EXCLUDED_NODES }}
@@ -46,6 +45,7 @@ jobs:
         DOMAIN: ${{ vars.DOMAIN }}
         NETWORK: ${{ vars.NETWORK }}
         ECOSYSTEM: ${{ vars.ECOSYSTEM }}
+        RPC_PROVIDER: ${{ vars.RPC_PROVIDER }}
         ACCESS_CONTROLLER: ${{ vars.ACCESS_CONTROLLER }}
         FEE_MODEL: ${{ vars.FEE_MODEL }}
         DURATION: ${{ vars.DURATION }}


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Due to an error on Ape CLI, setting directly the RPC URL in the `--network` option is not working. So these changes are aimed to use the configuration of ape-infura plugin, i.e. set `RPC_PROVIDER` to 'infura' and set `WEB3_INFURA_API_KEY` with the API Key.

