### PR TITLE
Upgrade upload and dowload artifact actions to v4

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -24,7 +24,7 @@ jobs:
       run: pip3 install -e . -r requirements.txt
 
     - name: Download Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: heartbeat-rituals
         path: rituals.json

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -51,7 +51,7 @@ jobs:
         DURATION: ${{ vars.DURATION }}
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: heartbeat-rituals
         path: heartbeat-rituals.json


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
v3 of actions/upload-artifact and actions/download-artifact are deprecated [1], so the execution of workflows that uses these fails.

[1] https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
