### PR TITLE
Fix RPC_PROVIDER env variable in evaluate workflow

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -39,4 +39,4 @@ jobs:
         DOMAIN: ${{ vars.DOMAIN }}
         NETWORK: ${{ vars.NETWORK }}
         ECOSYSTEM: ${{ vars.ECOSYSTEM }}
-        RPC_PROVIDER: ${{ secrets.RPC_PROVIDER }}
+        RPC_PROVIDER: ${{ vars.RPC_PROVIDER }}


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
RPC_PROVIDER will be stored as environment variable instead of secret, as @derekpierre realized in https://github.com/nucypher/nucypher-contracts/pull/374#discussion_r2081548375.
