### PR TITLE
Fix bug where proxy contract address was not correctly being determined

### DIFF
--- a/deployment/params.py
+++ b/deployment/params.py
@@ -419,7 +419,7 @@ class ProxyParameters:
                     contract_names=contract_names,
                     constants=constants,
                     contract_name=contract_name,
-                    check_for_proxy_instances=False,
+                    check_for_proxy_instances=True,
                 ),
             )
             contracts_proxy_info.update({contract_name: proxy_info})

--- a/deployment/params.py
+++ b/deployment/params.py
@@ -153,9 +153,11 @@ class ContractName(Variable):
 
         if self.check_for_proxy_instances:
             # check if contract is proxied - if so return proxy contract instead
-            proxy_info = chain.contracts.get_proxy_info(contract_instance.address)
-            if proxy_info:
-                return proxy_info.address
+            proxy_info_keys = chain.contracts.proxy_infos.memory.keys()
+            for proxy_address in proxy_info_keys:
+                proxy_info = chain.contracts.get_proxy_info(proxy_address)
+                if proxy_info and proxy_info.target == contract_instance.address:
+                    return proxy_address
 
         return contract_instance.address
 


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
The logic for obtaining the proxy contract for a deployed contract was not correctly being determined. Consequently, for deployment params that did something like:
```
  - MockPolygonRoot:
      constructor:
        _rootApplication: $TACoApplication
 ```
and `$TACoApplication` was deployed as a proxied contract, the implementation address was used instead of the proxy.

There was an update, https://github.com/nucypher/nucypher-contracts/commit/a30418e06fdec37ef6e1b059807f0a123edc3f80, that was a part of https://github.com/nucypher/nucypher-contracts/pull/358, and changed as part of an update to the ape version being used, but it doesn't seem that the change was correct. While this code was incorrect, I don't believe it has been used because we've only been updating contracts since then, which doesn't utilize that code.

I've been testing the change with my signing infra work.

This was also a problem when used as part of proxy constructor parameters. For example:
```
    SigningCoordinatorChild:
      proxy:
        constructor:
          _data: $encode:initialize,$ThresholdSigningMultisigCloneFactory,$SigningCoordinatorDispatcher,$deployer
```

Where `SigningCoordinatorDispatcher` was deployed as a proxy - the implementation address was used, but this is now fixed.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
