### PR TITLE
Add excluded-nodes flag to heartbeat workflow

### DIFF
--- a/.github/scripts/initiate_dkg.sh
+++ b/.github/scripts/initiate_dkg.sh
@@ -17,7 +17,8 @@ ape run initiate_ritual                           \
 --access-controller ${ACCESS_CONTROLLER}          \
 --authority ${DKG_AUTHORITY_ADDRESS}              \
 --fee-model ${FEE_MODEL}                          \
---duration ${DURATION}
+--duration ${DURATION}                            \
+--excluded-nodes
 
 echo "All Heartbeat Rituals Initiated"
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Some nodes are excluded from the heartbeats round due to protocol needs. The list of these nodes is included in the secrets of the repo, but the script was not enabling the corresponding tag.  

Note that if no path file is included after `--excluded-nodes` CLI option, the list is taken from environment variable as stated here: 

https://github.com/nucypher/nucypher-contracts/blob/8b9fad9428763c9f439039729cf6aa1d4577e3fb/scripts/initiate_ritual.py#L184-L192
