### PR TITLE
Fix "no matching distribution" error during Python dependencies installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ bitarray==3.3.1
 black==25.1.0; python_version >= '3.9'
 bump2version==1.0.1; python_version >= '3.5'
 cached-property==2.0.1; python_version >= '3.8'
-cachetools==6.0.0b3; python_version >= '3.9'
+cachetools==6.0.0; python_version >= '3.9'
 cchecksum==0.0.7; python_version >= '3.8' and python_version < '4'
 certifi==2025.1.31; python_version >= '3.6'
 cffi==1.17.1; python_version >= '3.8'


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
When installing dependencies running pip install -r `requirements.txt` using Python `3.12.4` an error occurs:

```
ERROR: Could not find a version that satisfies the requirement
cachetools==6.0.0b3
[...]
ERROR: no matching distribution found for cachetools==6.0.0b3
```

Using the last stable release version of cachetools (`v6.0.0`) fixes this.

Error example here:

https://github.com/nucypher/nucypher-contracts/actions/runs/15243478367/job/42866531600
