### PR TITLE
Add manual trigger for evaluate DKG workflow

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -1,6 +1,7 @@
 name: Evaluate DKG
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 5' # Every Monday at 05:00
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
This adds an option in Evaluate DKG workflow (https://github.com/nucypher/nucypher-contracts/actions/workflows/evaluate.yml) to start the workflow manually.
