### PR TITLE
Use dawidd6 download artifact action

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -25,8 +25,9 @@ jobs:
       run: pip3 install -e . -r requirements.txt
 
     - name: Download Artifact
-      uses: actions/download-artifact@v4
+      uses: dawidd6/action-download-artifact@v9
       with:
+        workflow: evaluate.yml
         name: heartbeat-rituals
 
     - name: Evaluate Ritual


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
This simplifies the process of downloading an artifact uploaded in another workflow.

The official download-artifact Github action is not able to download artifacts from other workflows (or at least, not if you do not manually specify the run-id of the workflow that uploaded the data).