### PR TITLE
Add return of error code (1) for initiate_ritual

### DIFF
--- a/.github/scripts/initiate_dkg.sh
+++ b/.github/scripts/initiate_dkg.sh
@@ -20,5 +20,10 @@ ape run initiate_ritual                           \
 --duration ${DURATION}                            \
 --excluded-nodes
 
-echo "All Heartbeat Rituals Initiated"
+if [ $? -ne 0 ]; then
+    echo "❗️ DKG heartbeat round failed"
+    exit 1
+fi
+
+echo "✅ All Heartbeat Rituals Initiated"
 

--- a/scripts/initiate_ritual.py
+++ b/scripts/initiate_ritual.py
@@ -229,14 +229,17 @@ def cli(
         # TODO: Failure recovery? (not enough funds, outages, etc.)
         # Initiate the ritual(s)
         transactor = Transactor(account=account, autosign=auto)
-        result = transactor.transact(
-            coordinator_contract.initiateRitual,
-            fee_model_contract.address,
-            cohort,
-            authority,
-            duration,
-            access_controller_contract.address,
-        )
+        try:
+            result = transactor.transact(
+                coordinator_contract.initiateRitual,
+                fee_model_contract.address,
+                cohort,
+                authority,
+                duration,
+                access_controller_contract.address,
+            )
+        except Exception as e:
+            raise click.ClickException(f"Failed to initiate ritual.\n{e}")
 
         ritual_id = result.events[0].ritualId
         rituals[ritual_id] = cohort


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Up to now, the script initiate_dkg.sh, aimed to be used on GitHub workflows, doesn't return an error code even if the initiate_ritual ape script fails. So the Github actions seems to be executed properly when it is not.

With these changes, the Github workflow will appear as failed when the script fails.
