### PR TITLE
Add ETHERSCAN_API_KEY to env vars for DKG rounds

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -37,6 +37,7 @@ jobs:
         # Secret environment variables (secrets)
         APE_ACCOUNTS_automation_PASSPHRASE: ${{ secrets.DKG_INITIATOR_PASSPHRASE }}
         WEB3_INFURA_API_KEY: ${{ secrets.WEB3_INFURA_API_KEY }}
+        ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         POLYGONSCAN_API_KEY: ${{ secrets.POLYGONSCAN_API_KEY }}
         EXCLUDED_NODES: ${{ secrets.EXCLUDED_NODES }}
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
APE needs an environment variable with ETHERSCAN API KEY during the compilation of the contracts, which is done every time the DKG heartbeat workflow is run. Without this, the compilation step return several errors as seen here:

 https://github.com/nucypher/nucypher-contracts/actions/runs/15553270092/job/43787969884#step:7:261
 
 ```
 ERROR:    Attempted to retrieve contract type from explorer 'etherscan' from address '0x4986b26f18ECA98474D85Ea583F99452983DCA1D' but encountered an exception: Response indicated failure: Missing/Invalid API Key
 ```