### PR TITLE
Increase tx confirmation timeout for polygon

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -32,6 +32,10 @@ ethereum:
   mainnet:
     transaction_acceptance_timeout: 600 # 10 minutes
 
+polygon:
+  mainnet:
+    transaction_acceptance_timeout: 600 # 10 minutes
+
 etherscan:
   ethereum:
     rate_limit: 5


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
The acceptance timeout for polygon transaction confirmation is increased from 2 minutes (default value) to 10 minutes, as we do for ethereum network.

This should reduce the chances of this type of error happening:

```bash
Error: Failed to initiate ritual.
Transaction '0x2b86b6297798be6ee48b9e22d9b6fcf23611c2fc1f4e0973764e2a546d1b0940' not found. Error: Transaction '0x2b86b6297798be6ee48b9e22d9b6fcf23611c2fc1f4e0973764e2a546d1b0940' is not in the chain after 120 seconds
```