### PR TITLE
Apply Etherscan rate_limit to polygon calls

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -39,6 +39,8 @@ polygon:
 etherscan:
   ethereum:
     rate_limit: 5
+  polygon:
+    rate_limit: 5
 
 test:
   mnemonic: test test test test test test test test test test test junk


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
The rate_limit was applied to the Etherscan calls done to Ethereum network. Now, we are adding this limit to the calls made to the Polygon network. 
