### PR TITLE
Check status code of node response on evaluate_heartbeat script

### DIFF
--- a/scripts/evaluate_heartbeat.py
+++ b/scripts/evaluate_heartbeat.py
@@ -89,7 +89,11 @@ def investigate_offender(
                             verify=False,
                             timeout=20,
                         )
+                        if node_status.status_code != 200:
+                            raise requests.ConnectionError
+
                         version = node_status.json().get("version", "Unknown")
+
                         offenders[ritual_id][address]["version"] = version
 
                         if version != "Unknown" and version != latest_version:


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Up to now, the script crashes if the node response to a `GET` is a result's code different than 200.

```
  File "/Users/manumonti/repos/nucypher-contracts/scripts/evaluate_heartbeat.py", line 94, in investigate_offender
    version = node_status.json().get("version", "Unknown")
              ^^^^^^^^^^^^^^^^^^
  File "/Users/manumonti/.pyenv/versions/3.12.4/envs/nucypher-contracts/lib/python3.12/site-packages/requests/models.py", line 978, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

With this change, the script first checks if the response code is 200 and avoids to crash if it is not.
