### PR TITLE
Fix node removal from excluded nodes list

### DIFF
--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -258,7 +258,8 @@ def get_heartbeat_cohorts(
 
     # Exclude nodes that are in the excluded_nodes list
     for node in excluded_nodes:
-        staking_providers.remove(to_checksum_address(node))
+        if to_checksum_address(node) in staking_providers:
+            staking_providers.remove(to_checksum_address(node))
 
     cohorts = _generate_heartbeat_cohorts(staking_providers)
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
When we add to the excluded nodes list a node that is not part of the round (maybe because the node is shut down, so the script is not considering it to be part of the heartbeat rond), the script returns an error since it is trying to remove something (`node`) from a list that is not containing that element.

This change fixes it.