### PR TITLE
Set excluded nodes as GH var instead of secret

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -39,7 +39,6 @@ jobs:
         WEB3_INFURA_API_SECRET: ${{ secrets.WEB3_INFURA_API_SECRET }}
         ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         POLYGONSCAN_API_KEY: ${{ secrets.POLYGONSCAN_API_KEY }}
-        EXCLUDED_NODES: ${{ secrets.EXCLUDED_NODES }}
 
         # Non-secret environment variables (config)
         DKG_AUTHORITY_ADDRESS: ${{ vars.DKG_AUTHORITY_ADDRESS }}
@@ -50,6 +49,7 @@ jobs:
         ACCESS_CONTROLLER: ${{ vars.ACCESS_CONTROLLER }}
         FEE_MODEL: ${{ vars.FEE_MODEL }}
         DURATION: ${{ vars.DURATION }}
+        EXCLUDED_NODES: ${{ vars.EXCLUDED_NODES }}
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
There is no reason to have the list of excluded nodes of DKG heartbeat rituals as GH actions secrets instead of variables.

Also, it is easier to troubleshoot the workflow if this is not a secret because the logs will not hide this information.