### PR TITLE
Add ReadTimeout error handling when status check

### DIFF
--- a/scripts/evaluate_heartbeat.py
+++ b/scripts/evaluate_heartbeat.py
@@ -101,7 +101,7 @@ def investigate_offender(
                                 f"Old Version ({version})"
                             )
                             outdated_nodes += 1
-                    except requests.ConnectionError:
+                    except (requests.ConnectionError, requests.exceptions.ReadTimeout):
                         offenders[ritual_id][address]["version"] = "Unknown"
                         offenders[ritual_id][address]["reasons"].append("Node is unreachable")
                         unreachable_nodes += 1


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
When a node is failing because some internal error, so it is up but is not managing properly the `get` requests, it may take more than the timeout duration in return an answer (usually error 500).

When the script reaches the timeout for the get request asking for the status of the node, an exception `requests.exceptions.ReadTimeout:` is raised. This was not properly handled, so the script stop running.

Now, this exception is handled.

So any node taking more than `timeout` duration to answer will be treated as  `Node unreachable`.
 