### PR TITLE
Remove prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
-    hooks:
-      - id: prettier
-
   - repo: local
     hooks:
       - id: lint-sol


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Since we don't have javascript or typescript code here, and the formatting and linting of Python code is made by black and flake8, it is no need to check every commit with prettier.

Solidity linting tool is kept here. This uses prettier, but as long as the npm package is installed, it will continue working when solidity files are modified.

**Why it's needed:**
Prettier keeps returning an error with every `git commit`. This is annoying since we have to run `git commit` to run the rest of linters and formatters (black, flake8, isort) and then `git commit --no-verify` to avoid the prettier error.

```
▶ git commit
black....................................................................Passed
flake8...................................................................Passed
isort....................................................................Passed
prettier.................................................................Failed
- hook id: prettier
- exit code: 1

[error] Named export 'util' not found. The requested module 'prettier' is a CommonJS module, which may not support all module.exports as named exports.
[error] CommonJS modules can always be imported via the default export, for example using:
[error] 
[error] import pkg from 'prettier';
[error] const { util, version } = pkg;
[error]

lint solidity........................................(no files to check)Skipped
```
