### PR TITLE
Allow ability to transfer cohort authority for active signing cohort

### DIFF
--- a/contracts/contracts/coordination/SigningCoordinator.sol
+++ b/contracts/contracts/coordination/SigningCoordinator.sol
@@ -38,6 +38,12 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
     event TimeoutChanged(uint32 oldTimeout, uint32 newTimeout);
     event MaxCohortSizeChanged(uint16 oldSize, uint16 newSize);
 
+    event CohortAuthorityTransferred(
+        uint32 indexed cohortId,
+        address indexed previousAuthority,
+        address indexed newAuthority
+    );
+
     struct SigningCohortParticipant {
         address provider;
         address signerAddress;
@@ -189,6 +195,19 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
         return cohort.chains;
     }
 
+    function getAuthority(uint32 cohortId) external view returns (address) {
+        return signingCohorts[cohortId].authority;
+    }
+
+    function transferCohortAuthority(uint32 cohortId, address newAuthority) external {
+        SigningCohort storage cohort = signingCohorts[cohortId];
+        require(isCohortActive(cohort), "Cohort is not active");
+        address previousAuthority = cohort.authority;
+        require(msg.sender == previousAuthority, "Sender not cohort authority");
+        cohort.authority = newAuthority;
+        emit CohortAuthorityTransferred(cohortId, previousAuthority, newAuthority);
+    }
+
     function initiateSigningCohort(
         uint256 chainId,
         address authority,
@@ -242,10 +261,7 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
     ) external {
         SigningCohort storage signingCohort = signingCohorts[cohortId];
         require(isCohortActive(signingCohort), "Cohort not active");
-        require(
-            signingCohort.authority == msg.sender,
-            "Only the cohort authority can set conditions"
-        );
+        require(signingCohort.authority == msg.sender, "Sender not cohort authority");
         // chainId must already be deployed for the cohort
         bool chainDeployed = false;
         for (uint256 i = 0; i < signingCohort.chains.length; i++) {

--- a/contracts/contracts/coordination/SigningCoordinator.sol
+++ b/contracts/contracts/coordination/SigningCoordinator.sol
@@ -204,6 +204,7 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
     function transferCohortAuthority(uint32 cohortId, address newAuthority) external {
         SigningCohort storage cohort = signingCohorts[cohortId];
         require(isCohortActive(cohort), "Cohort is not active");
+        require(newAuthority != address(0), "Invalid new authority");
         address previousAuthority = cohort.authority;
         require(msg.sender == previousAuthority, "Sender not cohort authority");
         cohort.authority = newAuthority;

--- a/contracts/contracts/coordination/SigningCoordinator.sol
+++ b/contracts/contracts/coordination/SigningCoordinator.sol
@@ -44,6 +44,8 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
         address indexed newAuthority
     );
 
+    event SigningCohortExtended(uint32 indexed cohortId, uint32 endTimestamp);
+
     struct SigningCohortParticipant {
         address provider;
         address signerAddress;
@@ -411,11 +413,9 @@ contract SigningCoordinator is Initializable, AccessControlDefaultAdminRulesUpgr
         uint32 additionalDuration
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         SigningCohort storage signingCohort = signingCohorts[cohortId];
-        // TODO: while it's good to check if the cohort is active, it is
-        // not necessary at the moment
-        // require(isCohortActive(signingCohort), "Cohort not active");
+        require(isCohortActive(signingCohort), "Cohort not active");
         require(additionalDuration > 0, "Invalid duration");
-        uint32 newEndTimestamp = signingCohort.endTimestamp + additionalDuration;
-        signingCohort.endTimestamp = newEndTimestamp;
+        signingCohort.endTimestamp += additionalDuration;
+        emit SigningCohortExtended(cohortId, signingCohort.endTimestamp);
     }
 }

--- a/tests/test_signing_coordinator.py
+++ b/tests/test_signing_coordinator.py
@@ -444,12 +444,26 @@ def test_signing_ritual(
 
     # extend duration
     additional_duration = 60 * 60 * 24
+
+    with ape.reverts("Cohort not active"):
+        signing_coordinator.extendSigningCohortDuration(999, additional_duration, sender=deployer)
+
+    with ape.reverts("Invalid duration"):
+        signing_coordinator.extendSigningCohortDuration(signing_cohort_id, 0, sender=deployer)
+
     current_end = signing_coordinator.signingCohorts(signing_cohort_id)["endTimestamp"]
-    _ = signing_coordinator.extendSigningCohortDuration(
+    tx = signing_coordinator.extendSigningCohortDuration(
         signing_cohort_id, additional_duration, sender=deployer
     )
     updated_end_timestamp = signing_coordinator.signingCohorts(signing_cohort_id)["endTimestamp"]
     assert updated_end_timestamp == current_end + additional_duration
+    events = [event for event in tx.events if event.event_name == "SigningCohortExtended"]
+    assert events == [
+        signing_coordinator.SigningCohortExtended(
+            cohortId=signing_cohort_id,
+            endTimestamp=updated_end_timestamp,
+        )
+    ]
 
     # transfer cohort authority
     with ape.reverts("Cohort is not active"):

--- a/tests/test_signing_coordinator.py
+++ b/tests/test_signing_coordinator.py
@@ -450,3 +450,46 @@ def test_signing_ritual(
     )
     updated_end_timestamp = signing_coordinator.signingCohorts(signing_cohort_id)["endTimestamp"]
     assert updated_end_timestamp == current_end + additional_duration
+
+    # transfer cohort authority
+    with ape.reverts("Cohort is not active"):
+        signing_coordinator.transferCohortAuthority(999, deployer.address, sender=initiator)
+
+    with ape.reverts("Sender not cohort authority"):
+        signing_coordinator.transferCohortAuthority(
+            signing_cohort_id, deployer.address, sender=deployer
+        )
+
+    tx = signing_coordinator.transferCohortAuthority(
+        signing_cohort_id, deployer.address, sender=initiator
+    )
+    events = [event for event in tx.events if event.event_name == "CohortAuthorityTransferred"]
+    assert events == [
+        signing_coordinator.CohortAuthorityTransferred(
+            cohortId=signing_cohort_id,
+            previousAuthority=initiator.address,
+            newAuthority=deployer.address,
+        )
+    ]
+    assert signing_coordinator.getAuthority(signing_cohort_id) == deployer.address
+    with ape.reverts("Sender not cohort authority"):
+        # initiator no longer authority and can't set conditions
+        tx = signing_coordinator.setSigningCohortConditions(
+            signing_cohort_id, chain.chain_id, time_condition, sender=initiator
+        )
+
+    tx = signing_coordinator.setSigningCohortConditions(
+        # deployer can set conditions
+        signing_cohort_id,
+        chain.chain_id,
+        time_condition,
+        sender=deployer,
+    )
+    events = [event for event in tx.events if event.event_name == "SigningCohortConditionsSet"]
+    assert events == [
+        signing_coordinator.SigningCohortConditionsSet(
+            cohortId=signing_cohort_id,
+            chainId=chain.chain_id,
+            conditions=time_condition,
+        )
+    ]

--- a/tests/test_signing_coordinator.py
+++ b/tests/test_signing_coordinator.py
@@ -469,6 +469,11 @@ def test_signing_ritual(
     with ape.reverts("Cohort is not active"):
         signing_coordinator.transferCohortAuthority(999, deployer.address, sender=initiator)
 
+    with ape.reverts("Invalid new authority"):
+        signing_coordinator.transferCohortAuthority(
+            signing_cohort_id, "0x" + "0" * 40, sender=initiator
+        )
+
     with ape.reverts("Sender not cohort authority"):
         signing_coordinator.transferCohortAuthority(
             signing_cohort_id, deployer.address, sender=deployer


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Admin cleanup:
- Allow ability to transfer cohort authority for active cohort
- Ensure that only active cohorts can have their duration extended


**Notes for reviewers:**

Please confirm that these changes don't affect upgradeability.
